### PR TITLE
fix(docs): remove wrong dashes in JSDoc @param documentation

### DIFF
--- a/docs/stark-core/ERROR_HANDLING.md
+++ b/docs/stark-core/ERROR_HANDLING.md
@@ -1,6 +1,6 @@
 # Stark Default Error Handling
 
-Stark provides its own error handler, StarkErrorHandler, that overrides [ Angular's default ErrorHandler](https://angular.io/api/core/ErrorHandler).
+Stark provides its own error handler, StarkErrorHandler, that overrides [Angular's default ErrorHandler](https://angular.io/api/core/ErrorHandler).
 
 This handler will dispatch a StarkUnhandledError action to the application Store which you can treat as you want.
 

--- a/docs/stark-core/TESTING_SUBPACKAGE.md
+++ b/docs/stark-core/TESTING_SUBPACKAGE.md
@@ -1,0 +1,70 @@
+# Stark Core Testing subpackage
+
+> @nationalbankbelgium/stark-core/testing
+
+Subpackage of Stark Core that contains the mock classes that come in hand when implementing unit tests that depend on
+any of the main services provided by Stark Core.
+
+## Mock Classes
+
+The mock classes provided by this subpackage are the following:
+
+-   [MockStarkHttpService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkHttpService.html)
+-   [MockStarkLoggingService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkLoggingService.html)
+-   [MockStarkRoutingService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkRoutingService.html)
+-   [MockStarkSessionService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkSessionService.html)
+-   [MockStarkUserService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkUserService.html)
+-   [MockStarkXsrfService](https://stark.nbb.be/api-docs/stark-core/latest/classes/MockStarkXsrfService.html)
+
+## Usage
+
+The mock classes of this subpackage can be imported as follows:
+
+```typescript
+import { MockStarkSessionService } from "@nationalbankbelgium/stark-core/testing";
+```
+
+The mock classes implement the base interface of the service they mock. So you just need provide the mock in your `TestingModule`:
+
+```typescript
+TestBed.configureTestingModule({
+    imports: [...],
+    declarations: [...],
+    providers: [
+        ...
+        { provide: STARK_SESSION_SERVICE, useValue: new MockStarkSessionService() },
+        ...
+    ]
+});
+```
+
+Then you can just inject the Stark service via the TestBed using its corresponding `InjectionToken`:
+
+```typescript
+// this will inject the instantiated mock class
+mockSessionService = TetBed.get(STARK_SESSION_SERVICE);
+```
+
+In fact, every method of the base interface is simply mocked
+with a [Jasmine Spy](https://jasmine.github.io/api/3.5/Spy.html) which can then be used in the unit tests to:
+
+-   return custom values
+-   override a method with a custom function
+-   asserting that they are actually called
+-   do any other operation than can be performed with an Spy.
+
+For example:
+
+```typescript
+// returning custom value
+mockSessionService.getCurrentLanguage.and.returnValue(of("fr"));
+
+// overriding a method with a custom function
+mockSessionService.getCurrentLanguage.and.callFake(() => {
+	// some custom logic to return a specific value
+});
+
+// asserting that a method was indeed called
+expect(mockSessionService.setCurrentLanguage).toHaveBeenCalledTimes(1);
+expect(mockSessionService.setCurrentLanguage).toHaveBeenCalledWith("nl");
+```

--- a/docs/stark-core/summary.json
+++ b/docs/stark-core/summary.json
@@ -10,5 +10,9 @@
   {
     "title": "Default Error Handling",
     "file": "ERROR_HANDLING.md"
+  },
+  {
+    "title": "Testing Subpackage",
+    "file": "TESTING_SUBPACKAGE.md"
   }
 ]

--- a/packages/stark-core/README.md
+++ b/packages/stark-core/README.md
@@ -7,6 +7,13 @@
 
 # Stark Core
 
-Stark's Core module (aka stark-core) provides the foundations of the Stark framework.
+Stark's Core package (aka stark-core) provides the foundations of the Stark framework.
 
 **[Getting Started](https://stark.nbb.be/api-docs/stark-core/latest/additional-documentation/getting-started.html)**
+
+## Testing subpackage
+
+Stark Core comes also with the subpackage `@nationalbankbelgium/stark-core/testing` which contains the mock classes that come in hand
+when implementing unit tests that depend on any of the main services provided by Stark Core.
+
+**[Using Stark Core mock classes](https://stark.nbb.be/api-docs/stark-core/latest/additional-documentation/testing-subpackage.html)**

--- a/packages/stark-core/package.json
+++ b/packages/stark-core/package.json
@@ -52,7 +52,7 @@
     "clean": "npx rimraf dist",
     "clean:modules": "npx rimraf ./node_modules package-lock.json",
     "clean:all": "npm run clean && npm run clean:modules",
-    "docs": "node ../../node_modules/@compodoc/compodoc/bin/index-cli src",
+    "docs": "compodoc",
     "docs:coverage": "npm run docs -- --coverageTest 85 --coverageTestThresholdFail true",
     "docs:serve": "npm run docs -- --watch --serve --port 4321",
     "ngc": "node ../../node_modules/@angular/compiler-cli/src/main.js -p ./tsconfig.json",

--- a/packages/stark-core/src/common/bootstrap/abstract-stark-main.ts
+++ b/packages/stark-core/src/common/bootstrap/abstract-stark-main.ts
@@ -7,19 +7,28 @@ import { StarkEnvironment } from "../environment";
 
 /**
  * Parent class for bootstrapping Stark applications.
+ *
  * It handles the DOMContentLoaded event of the Web browser in order to bootstrap the application.
  * This class also supports HMR in development mode.
  */
 export abstract class AbstractStarkMain implements StarkMain {
+	/**
+	 * Class constructor
+	 * @param environment - Environment constant provided by the current Angular build
+	 */
 	protected constructor(protected environment: StarkEnvironment) {
 		// no-op
 	}
 
 	/**
-	 * Must be implemented by children classes. Called within bootstrapDomReady (i.e., when the DOM has been loaded)
+	 * Must be implemented by children classes. Called within {@link #bootstrapDomReady|bootstrapDomReady} (i.e., when the DOM has been loaded)
 	 */
 	public abstract main: () => Promise<any>;
 
+	/**
+	 * Callback function for the `DOMContentLoaded` event listener.
+	 * Removes itself when triggered and calls the {@link #initialize|initialize} method.
+	 */
 	public mainWrapper = (): void => {
 		// written like this because otherwise "this" will not be captured :)
 		// no need for the event listener after this
@@ -111,7 +120,7 @@ We need great software developers like you! https://jobs.nbb.be
 	/**
 	 * Configure HMR
 	 * Code based on: https://github.com/angular/angular-cli/wiki/stories-configure-hmr
-	 * Reference: https://github.com/gdi2290/angular-hmr
+	 * Reference: https://github.com/PatrickJS/angular-hmr
 	 * @ignore
 	 */
 	protected bootstrapHmr: Function = (module: any, bootstrap: () => Promise<NgModuleRef<any>>) => {
@@ -148,12 +157,12 @@ We need great software developers like you! https://jobs.nbb.be
 			console.log("Customizing configuration for development!");
 
 			// Ensure that we get detailed stack tracks during development (useful with node & Webpack)
-			// Reference: http://stackoverflow.com/questions/7697038/more-than-10-lines-in-a-node-js-stack-error
+			// Reference: https://stackoverflow.com/questions/7697038/more-than-10-lines-in-a-node-js-stack-error
 			Error.stackTraceLimit = Infinity;
 			require("zone.js/dist/long-stack-trace-zone");
 
 			// Enable Angular debug tools in the dev console
-			// https://github.com/angular/angular/blob/86405345b781a9dc2438c0fbe3e9409245647019/TOOLS_JS.md
+			// https://github.com/angular/angular/blob/master/docs/TOOLS.md
 			const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
 			const cmpRef: ComponentRef<any> = appRef.components[0];
 			enableDebugTools(cmpRef);

--- a/packages/stark-core/src/common/bootstrap/abstract-stark-main.ts
+++ b/packages/stark-core/src/common/bootstrap/abstract-stark-main.ts
@@ -14,7 +14,7 @@ import { StarkEnvironment } from "../environment";
 export abstract class AbstractStarkMain implements StarkMain {
 	/**
 	 * Class constructor
-	 * @param environment - Environment constant provided by the current Angular build
+	 * @param environment Environment constant provided by the current Angular build
 	 */
 	protected constructor(protected environment: StarkEnvironment) {
 		// no-op
@@ -146,7 +146,7 @@ We need great software developers like you! https://jobs.nbb.be
 	/**
 	 * Modify/decorate the NgModule instance created by Angular.
 	 * Adapt the configuration based on the current environment
-	 * @param moduleRef - NgModule instance created by Angular for a given platform.
+	 * @param moduleRef NgModule instance created by Angular for a given platform.
 	 */
 	public decorateModule = (moduleRef: NgModuleRef<any>): NgModuleRef<any> => {
 		// written like this because otherwise "this" will not be captured :)

--- a/packages/stark-core/src/common/bootstrap/stark-main.intf.ts
+++ b/packages/stark-core/src/common/bootstrap/stark-main.intf.ts
@@ -17,7 +17,7 @@ export interface StarkMain {
 	/**
 	 * Function to modify/decorate the module instance created by Angular for a given platform.
 	 * Useful to enable/disable some Angular specifics such as the debug tools.
-	 * @param moduleRef - NgModule instance created by Angular for a given platform.
+	 * @param moduleRef NgModule instance created by Angular for a given platform.
 	 */
 	decorateModule(moduleRef: NgModuleRef<any>): NgModuleRef<any>;
 }

--- a/packages/stark-core/src/common/environment/environment.intf.ts
+++ b/packages/stark-core/src/common/environment/environment.intf.ts
@@ -5,14 +5,14 @@ import { NgModuleRef } from "@angular/core";
  */
 export interface StarkEnvironment {
 	/**
-	 * Whether the current environment is production (as described in Angular CLI Wiki)
-	 * @link https://github.com/angular/angular-cli/wiki/stories-application-environments
+	 * Whether the current environment is production, as described
+	 * in {@link https://v7.angular.io/guide/build#configuring-application-environments|Angular docs: Configuring application environments}
 	 */
 	production: boolean;
 
 	/**
-	 * Whether the current environment has Hot Module Replacement enabled (as described in Angular CLI Wiki)
-	 * @link https://github.com/angular/angular-cli/wiki/stories-configure-hmr
+	 * Whether the current environment has Hot Module Replacement enabled, as described
+	 * in {@link https://github.com/angular/angular-cli/wiki/stories-configure-hmr|Angular CLI Wiki: Configure Hot Module Replacement}
 	 */
 	hmr: boolean;
 

--- a/packages/stark-core/src/common/environment/environment.intf.ts
+++ b/packages/stark-core/src/common/environment/environment.intf.ts
@@ -25,7 +25,7 @@ export interface StarkEnvironment {
 	/**
 	 * Function to modify/decorate the module instance created by Angular for a given platform.
 	 * Useful to enable/disable some Angular specifics such as the debug tools.
-	 * @param moduleRef - NgModule instance created by Angular for a given platform.
+	 * @param moduleRef NgModule instance created by Angular for a given platform.
 	 */
 	decorateModule(moduleRef: NgModuleRef<any>): NgModuleRef<any>;
 }

--- a/packages/stark-core/src/common/translations/merge-translations.ts
+++ b/packages/stark-core/src/common/translations/merge-translations.ts
@@ -8,7 +8,7 @@ import cloneDeep from "lodash-es/cloneDeep";
  * without losing any existing translations.
  *
  * There are three 'levels' that can provide translations:
- *   1. Common: for the Stark framework, they are stored in the 'translations' folder in the current folder.
+ *   1. Common: for the Stark framework, they are stored in the `translations` folder in the current folder.
  *   2. Module: each module contains it's own translations, to make Stark fully modular.
  *   3. App: the translations provided by the client application that implements the Stark framework.
  *
@@ -17,10 +17,10 @@ import cloneDeep from "lodash-es/cloneDeep";
  * translation with the same key, the translation with the highest priority 'wins'.
  *
  * Functionality:
- * First the existing translations are stored in a variable 'translations'.
- * The function then iterates over the 'args' parameters.
+ * First the existing translations are stored in a variable `translations`.
+ * The function then iterates over the `args` parameters.
  * For each language, the following steps are processed:
- *   1. The translateService is cleaned (shouldMerge = false)
+ *   1. The translateService is cleaned (shouldMerge = `false`)
  *   2. The 'common' translations are added in the translateService
  *   3. The 'module' translations are added in the translateService, replacing any existing translations
  *   4. The 'stored' translations are added in the translateService, replacing any existing translations

--- a/packages/stark-core/src/common/translations/merge-translations.ts
+++ b/packages/stark-core/src/common/translations/merge-translations.ts
@@ -25,8 +25,8 @@ import cloneDeep from "lodash-es/cloneDeep";
  *   3. The 'module' translations are added in the translateService, replacing any existing translations
  *   4. The 'stored' translations are added in the translateService, replacing any existing translations
  *
- * @param translateService - A reference to the translateService instance
- * @param localesToMerge - A list of StarkLocales that contain the translations for a specific language
+ * @param translateService A reference to the translateService instance
+ * @param localesToMerge A list of StarkLocales that contain the translations for a specific language
  *
  * @example:
  *   mergeTranslations(this.translateService, english, french, dutch);

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
@@ -2,7 +2,7 @@ import { StarkBackend } from "../../../modules/http/entities/backend";
 import { InjectionToken } from "@angular/core";
 
 /**
- * The InjectionToken that defines the StarkApplicationConfig, in case an injection is needed.
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkApplicationConfig}
  */
 export const STARK_APP_CONFIG: InjectionToken<StarkApplicationConfig> = new InjectionToken<StarkApplicationConfig>("STARK_APP_CONFIG");
 
@@ -31,6 +31,7 @@ export interface StarkApplicationConfig {
 	 */
 	errorStateName: string;
 
+	// FIXME: remove obsolete property
 	/**
 	 * Enable Angular's debug runtime information.
 	 *
@@ -46,26 +47,30 @@ export interface StarkApplicationConfig {
 	debugLoggingEnabled: boolean;
 
 	/**
-	 * When the number of log messages reaches the loggingFlushPersistSize value,
+	 * When the number of log messages reaches the `loggingFlushPersistSize` value,
 	 * the log messages are sent to the back-end and removed from the redux store.
-	 * Default - 15
+	 *
+	 * Default: `15`
 	 */
 	loggingFlushPersistSize?: number;
 
 	/**
-	 * The loggingFlushApplicationId uniquely identifies the application.
-	 * It makes that the back-end can recognize your application.
+	 * Id that uniquely identifies the application when flushing the logs to the back-end.
+	 * It allows the back-end to recognize your application.
 	 */
 	loggingFlushApplicationId?: string;
 
 	/**
-	 * The loggingFlushResourceName defines the name of the logging resource on the back-end. Default: "logging"
+	 * Defines the name of the logging resource on the back-end.
+	 *
+	 * Default: `logging`
 	 */
 	loggingFlushResourceName?: string;
 
 	/**
 	 * Option to disable the logging flush if it not needed for the application.
-	 * Default - false
+	 *
+	 * Default: `false`
 	 */
 	loggingFlushDisabled?: boolean;
 
@@ -81,7 +86,8 @@ export interface StarkApplicationConfig {
 
 	/**
 	 * Enable router visualizer. Only in DEV (the router visualizer is not available in PROD)
-	 * Default - false
+	 *
+	 * Default: `false`
 	 */
 	routerVisualizerEnabled?: boolean;
 
@@ -92,23 +98,27 @@ export interface StarkApplicationConfig {
 
 	/**
 	 * Seconds before the session is ended (due to no user interaction) when the timeout warning event will be emitted.
-	 * Default - 15
+	 *
+	 * Default: `15`
 	 */
 	sessionTimeoutWarningPeriod: number;
 
 	/**
-	 * Interval in seconds between every "keepalive" ping. Default: 15
+	 * Interval in seconds between every `keepalive` ping.
+	 *
+	 * Default: `15`
 	 */
 	keepAliveInterval?: number;
 
 	/**
-	 * Url where the "keepalive" pings should be sent to
+	 * Url where the `keepalive` pings should be sent to
 	 */
 	keepAliveUrl?: string;
 
 	/**
-	 * Option to disable the keepAlive if it is not needed for the application.
-	 * Default - false
+	 * Option to disable the `keepAlive` mechanism if it is not needed for the application.
+	 *
+	 * Default: `false`
 	 */
 	keepAliveDisabled?: boolean;
 
@@ -135,41 +145,36 @@ export interface StarkApplicationConfig {
 	publicApp: boolean;
 
 	/**
-	 * Map containing the different back-ends that the application will interact with.
-	 * @link StarkBackend
+	 * Map containing the different {@link StarkBackend} objects that the application will interact with.
 	 */
 	backends: Map<string, StarkBackend>;
 
 	/**
-	 * Get a back-end by name
+	 * Get a {@link StarkBackend} by name
 	 *
-	 * @link StarkBackend
 	 * @param name - Name of the back-end object to get
-	 * @returns The requested backend object
+	 * @returns The requested `StarkBackend` object
 	 */
 	getBackend(name: string): StarkBackend;
 
 	/**
-	 * Add a back-end
+	 * Add a {@link StarkBackend}
 	 *
-	 * @link StarkBackend
-	 * @param backend - Back-end object to add
+	 * @param backend - `StarkBackend` object to add
 	 */
 	addBackend(backend: StarkBackend): void;
 
 	/**
-	 * Define all back-ends
+	 * Define all {@link StarkBackend} objects
 	 *
-	 * @link StarkBackend
-	 * @param backends - Array of back-end objects to add
+	 * @param backends - Array of `StarkBackend` objects to add
 	 */
 	setBackends(backends: StarkBackend[]): void;
 
-	/***
-	 * Get all currently defined back-end objects
+	/**
+	 * Get all currently defined {@link StarkBackend} objects
 	 *
-	 * @link StarkBackend
-	 * @returns A Map containing the different back-end objects
+	 * @returns A Map containing the different `StarkBackend` objects
 	 */
 	getBackends(): Map<string, StarkBackend>;
 }

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
@@ -152,7 +152,7 @@ export interface StarkApplicationConfig {
 	/**
 	 * Get a {@link StarkBackend} by name
 	 *
-	 * @param name - Name of the back-end object to get
+	 * @param name Name of the back-end object to get
 	 * @returns The requested `StarkBackend` object
 	 */
 	getBackend(name: string): StarkBackend;
@@ -160,14 +160,14 @@ export interface StarkApplicationConfig {
 	/**
 	 * Add a {@link StarkBackend}
 	 *
-	 * @param backend - `StarkBackend` object to add
+	 * @param backend `StarkBackend` object to add
 	 */
 	addBackend(backend: StarkBackend): void;
 
 	/**
 	 * Define all {@link StarkBackend} objects
 	 *
-	 * @param backends - Array of `StarkBackend` objects to add
+	 * @param backends Array of `StarkBackend` objects to add
 	 */
 	setBackends(backends: StarkBackend[]): void;
 

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
@@ -10,7 +10,7 @@ import { StarkMapIsValid, StarkMapNotEmpty } from "../../../validation/decorator
 /**
  * This class is only for serialization purposes
  * @ignore
- * @dynamic See: https://angular.io/guide/aot-compiler#strictmetadataemit
+ * @dynamic See: https://v7.angular.io/guide/aot-compiler#strictmetadataemit
  */
 export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	// FIXME: properties of the group "temp" are not used yet. Will they still be used?
@@ -181,20 +181,20 @@ export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	}
 
 	/**
-	 * Check whether the keepAlive option in the StarkApplicationConfig is disabled
+	 * Check whether the `keepAlive` option in the {@link StarkApplicationConfig} is disabled
 	 *
-	 * @param instance - the instance of the stark application configuration
-	 * @returns boolean - if keepAlive is in use, the value of keepAliveDisabled is set to false
+	 * @param instance - The instance of the stark application configuration
+	 * @returns Whether keepAlive is in use, the value of `keepAliveDisabled` is set to false
 	 */
 	public static validateIfKeepAliveEnabled(instance: StarkApplicationConfig): boolean {
 		return instance.keepAliveDisabled !== true;
 	}
 
 	/**
-	 * Check whether the loggingFlush option in the StarkApplicationConfig is disabled
+	 * Check whether the `loggingFlush` option in the {@link StarkApplicationConfig} is disabled
 	 *
-	 * @param instance - the instance of the stark application configuration
-	 * @returns boolean - if loggingFlush is in use, the value of loggingFlushDisabled is set to false
+	 * @param instance - The instance of the stark application configuration
+	 * @returns Whether loggingFlush is in use, the value of `loggingFlushDisabled` is set to false
 	 */
 	public static validateIfLoggingFlushEnabled(instance: StarkApplicationConfig): boolean {
 		return instance.loggingFlushDisabled !== true;

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
@@ -183,7 +183,7 @@ export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	/**
 	 * Check whether the `keepAlive` option in the {@link StarkApplicationConfig} is disabled
 	 *
-	 * @param instance - The instance of the stark application configuration
+	 * @param instance The instance of the stark application configuration
 	 * @returns Whether keepAlive is in use, the value of `keepAliveDisabled` is set to false
 	 */
 	public static validateIfKeepAliveEnabled(instance: StarkApplicationConfig): boolean {
@@ -193,7 +193,7 @@ export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	/**
 	 * Check whether the `loggingFlush` option in the {@link StarkApplicationConfig} is disabled
 	 *
-	 * @param instance - The instance of the stark application configuration
+	 * @param instance The instance of the stark application configuration
 	 * @returns Whether loggingFlush is in use, the value of `loggingFlushDisabled` is set to false
 	 */
 	public static validateIfLoggingFlushEnabled(instance: StarkApplicationConfig): boolean {

--- a/packages/stark-core/src/configuration/entities/language/language.entity.ts
+++ b/packages/stark-core/src/configuration/entities/language/language.entity.ts
@@ -5,7 +5,7 @@ import { StarkIsSupportedLanguage } from "../../../validation/decorators/is-supp
 
 /**
  * @ignore
- * @dynamic See: https://angular.io/guide/aot-compiler#strictmetadataemit
+ * @dynamic See: https://v7.angular.io/guide/aot-compiler#strictmetadataemit
  */
 export class StarkLanguageImpl implements StarkLanguage {
 	@IsNotEmpty({ always: true }) // validation must be performed always, regardless of validation groups used.

--- a/packages/stark-core/src/configuration/entities/metadata/application-metadata.entity.intf.ts
+++ b/packages/stark-core/src/configuration/entities/metadata/application-metadata.entity.intf.ts
@@ -2,14 +2,14 @@ import { StarkLanguage } from "../language";
 import { InjectionToken } from "@angular/core";
 
 /**
- * The InjectionToken that defines the Application Metadata, in case an injection is needed.
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkApplicationMetadata}
  */
 export const STARK_APP_METADATA: InjectionToken<StarkApplicationMetadata> = new InjectionToken<StarkApplicationMetadata>(
 	"STARK_APP_METADATA"
 );
 
 /**
- * Metadata that describes the current application build
+ * Metadata that describes the current application build.
  * An implementation should be instantiated and be available under the name defined in the constants.
  */
 export interface StarkApplicationMetadata {
@@ -44,8 +44,7 @@ export interface StarkApplicationMetadata {
 	deploymentTimestamp: string;
 
 	/**
-	 * Array of languages to be supported in the application
-	 * @link StarkLanguage
+	 * Array of {@link StarkLanguage} objects to be supported in the application
 	 */
 	supportedLanguages: StarkLanguage[];
 }

--- a/packages/stark-core/src/configuration/entities/metadata/application-metadata.entity.ts
+++ b/packages/stark-core/src/configuration/entities/metadata/application-metadata.entity.ts
@@ -50,9 +50,9 @@ export class StarkApplicationMetadataImpl implements StarkApplicationMetadata {
 
 	/**
 	 * Callback method provided by cerialize in order to post-process the de-serialized json object
-	 * @param instance - Instantiated object with its properties already
+	 * @param instance Instantiated object with its properties already
 	 * set as defined via the serializer annotations
-	 * @param json - Raw json object loaded from file
+	 * @param json Raw json object loaded from file
 	 */
 	public static OnDeserialized(instance: StarkApplicationMetadataImpl, json: any): void {
 		const supportedLanguages: string[] = json["supportedLanguages"];

--- a/packages/stark-core/src/configuration/entities/mock-data/mock-data.entity.intf.ts
+++ b/packages/stark-core/src/configuration/entities/mock-data/mock-data.entity.intf.ts
@@ -2,15 +2,21 @@ import { InjectionToken } from "@angular/core";
 import { StarkUser } from "../../../modules/user";
 
 /**
- * The InjectionToken that defines the StarkApplicationConfig, in case an injection is needed.
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkMockData}
  */
 export const STARK_MOCK_DATA: InjectionToken<StarkMockData> = new InjectionToken<StarkMockData>("STARK_MOCK_DATA");
 
 /**
- * Mock data entity
- * Describes how the mock data should look like when a developer wants to mock its backend data to be fetched via JSON Server
+ * Mock data entity that describes how the mock data should look like when a developer wants to mock its backend data to be fetched via JSON Server
  */
 export interface StarkMockData {
+	/**
+	 * Custom additional properties
+	 */
 	[key: string]: any;
+
+	/**
+	 * Array of `StarkUser` objects
+	 */
 	profiles?: StarkUser[];
 }

--- a/packages/stark-core/src/modules/error-handling/actions/error-handling.actions.ts
+++ b/packages/stark-core/src/modules/error-handling/actions/error-handling.actions.ts
@@ -14,13 +14,12 @@ export enum StarkErrorHandlingActionTypes {
 export class StarkUnhandledError implements Action {
 	/**
 	 * The type of action
-	 * @link StarkErrorHandlingActionTypes
 	 */
 	public readonly type: StarkErrorHandlingActionTypes.UNHANDLED_ERROR = StarkErrorHandlingActionTypes.UNHANDLED_ERROR;
 
 	/**
 	 * Class constructor
-	 * @param error - the error to display
+	 * @param error - The error to display
 	 */
 	public constructor(public error: any) {}
 }

--- a/packages/stark-core/src/modules/error-handling/actions/error-handling.actions.ts
+++ b/packages/stark-core/src/modules/error-handling/actions/error-handling.actions.ts
@@ -19,7 +19,7 @@ export class StarkUnhandledError implements Action {
 
 	/**
 	 * Class constructor
-	 * @param error - The error to display
+	 * @param error The error to display
 	 */
 	public constructor(public error: any) {}
 }

--- a/packages/stark-core/src/modules/error-handling/error-handling.module.ts
+++ b/packages/stark-core/src/modules/error-handling/error-handling.module.ts
@@ -5,8 +5,9 @@ import { StarkErrorHandler } from "./handlers/error-handler";
 export class StarkErrorHandlingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
@@ -23,7 +24,7 @@ export class StarkErrorHandlingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/error-handling/error-handling.module.ts
+++ b/packages/stark-core/src/modules/error-handling/error-handling.module.ts
@@ -25,7 +25,7 @@ export class StarkErrorHandlingModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/error-handling/error-handling.module.ts
+++ b/packages/stark-core/src/modules/error-handling/error-handling.module.ts
@@ -6,8 +6,8 @@ export class StarkErrorHandlingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
 		return {
@@ -23,8 +23,8 @@ export class StarkErrorHandlingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/error-handling/handlers/error-handler.ts
+++ b/packages/stark-core/src/modules/error-handling/handlers/error-handler.ts
@@ -4,16 +4,32 @@ import { StarkCoreApplicationState } from "../../../common/store";
 import { StarkUnhandledError } from "../actions";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "../../logging/services";
 
+/**
+ * Replacement for the default {@link https://v7.angular.io/api/core/ErrorHandler|ErrorHandler} from Angular
+ */
 @Injectable()
 export class StarkErrorHandler implements ErrorHandler {
+	/**
+	 * @ignore
+	 * @internal
+	 */
 	private _starkLoggingService?: StarkLoggingService;
+
+	/**
+	 * @ignore
+	 * @internal
+	 */
 	private _applicationStore?: Store<StarkCoreApplicationState>;
 
+	/**
+	 * Class constructor
+	 * @param injector - The Angular injector
+	 */
 	public constructor(private injector: Injector) {}
 
 	/**
-	 * This method will dispatch an error method, which the user can then handle
-	 * @param error the encountered error
+	 * Dispatches an {@link StarkUnhandledError} action which the user can then handle
+	 * @param error - The encountered error
 	 */
 	public handleError(error: any): void {
 		this.starkLoggingService.error("StarkErrorHandler: an error has occurred : ", error);
@@ -21,8 +37,9 @@ export class StarkErrorHandler implements ErrorHandler {
 	}
 
 	/**
-	 * Gets the StarkLoggingService from the Injector.
-	 * @throws When the service is not found (the StarkLoggingService is not provided in the app).
+	 * @ignore
+	 * @internal
+	 * @throws When the service is not found (the {@link StarkLoggingService} is not provided in the app).
 	 */
 	private get starkLoggingService(): StarkLoggingService {
 		if (typeof this._starkLoggingService === "undefined") {
@@ -34,7 +51,8 @@ export class StarkErrorHandler implements ErrorHandler {
 	}
 
 	/**
-	 * Gets the Application Store from the Injector.
+	 * @ignore
+	 * @internal
 	 * @throws When the Store is not found (the NGRX Store module is not imported in the app).
 	 */
 	private get applicationStore(): Store<StarkCoreApplicationState> {

--- a/packages/stark-core/src/modules/error-handling/handlers/error-handler.ts
+++ b/packages/stark-core/src/modules/error-handling/handlers/error-handler.ts
@@ -23,13 +23,13 @@ export class StarkErrorHandler implements ErrorHandler {
 
 	/**
 	 * Class constructor
-	 * @param injector - The Angular injector
+	 * @param injector The Angular injector
 	 */
 	public constructor(private injector: Injector) {}
 
 	/**
 	 * Dispatches an {@link StarkUnhandledError} action which the user can then handle
-	 * @param error - The encountered error
+	 * @param error The encountered error
 	 */
 	public handleError(error: any): void {
 		this.starkLoggingService.error("StarkErrorHandler: an error has occurred : ", error);

--- a/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
@@ -7,8 +7,8 @@ import { StarkHttpRequest, StarkQueryParam, StarkResource } from "../entities";
 export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Adds a header to the request
-	 * @param name - Header name
-	 * @param value - Header value. In case of multiple values, they should be provided in an array.
+	 * @param name Header name
+	 * @param value Header value. In case of multiple values, they should be provided in an array.
 	 * @returns The current builder
 	 */
 	setHeader(name: string, value: string | string[]): this;
@@ -16,10 +16,10 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Adds a query parameter to the request (if the parameter already exists it will be overwritten)
 	 *
-	 * @param name - Query parameter name
-	 * @param value - `StarkQueryParam` object to be used as the query parameter value
-	 * @param allowUndefined - (Optional) Whether to include the query parameter even if it has an `undefined` value. Default: `false`.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
+	 * @param name Query parameter name
+	 * @param value `StarkQueryParam` object to be used as the query parameter value
+	 * @param allowUndefined (Optional) Whether to include the query parameter even if it has an `undefined` value. Default: `false`.
+	 * @param allowEmpty (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	addQueryParameter(name: string, value: StarkQueryParam, allowUndefined?: boolean, allowEmpty?: boolean): this;
@@ -27,9 +27,9 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Adds query parameters to the request (adds them to the existing query parameters)
 	 *
-	 * @param params - Object containing the `StarkQueryParam` objects to be added to the request
-	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
+	 * @param params Object containing the `StarkQueryParam` objects to be added to the request
+	 * @param allowUndefined (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
+	 * @param allowEmpty (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	addQueryParameters(params: { [param: string]: StarkQueryParam }, allowUndefined?: boolean, allowEmpty?: boolean): this;
@@ -37,23 +37,23 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Sets query parameters to the request (all existing query parameters will be lost)
 	 *
-	 * @param params - Object containing the `StarkQueryParam` objects to be added to the request
-	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
+	 * @param params Object containing the `StarkQueryParam` objects to be added to the request
+	 * @param allowUndefined (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
+	 * @param allowEmpty (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	setQueryParameters(params: { [param: string]: StarkQueryParam }, allowUndefined?: boolean, allowEmpty?: boolean): this;
 
 	/**
 	 * Interpolates the parameters in the resource path with actual values
-	 * @param params - Object with the values to interpolate in the resource path
+	 * @param params Object with the values to interpolate in the resource path
 	 * @returns The current builder
 	 */
 	setPathParameters(params: { [param: string]: string }): this;
 
 	/**
 	 * Sets the number of times the request should be retried in case of error before emitting the failure
-	 * @param retryCount - Maximum number of attempts
+	 * @param retryCount Maximum number of attempts
 	 * @returns The current builder
 	 */
 	retry(retryCount: number): this;

--- a/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
@@ -1,8 +1,8 @@
 import { StarkHttpRequest, StarkQueryParam, StarkResource } from "../entities";
 
 /**
- * The StarkHttpBaseRequestBuilder interface is used to build a HTTP request.
- * Thanks to this class, headers, query parameters, ...  can be added to the request.
+ * The `StarkHttpBaseRequestBuilder` interface is used to build a {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest}.
+ * Thanks to this class, headers, query parameters, etc. can be added to the request.
  */
 export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
@@ -19,8 +19,8 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	 * @link StarkQueryParam
 	 * @param name - Query parameter name
 	 * @param value - Query parameter value
-	 * @param allowUndefined - (Optional) Whether to include the query parameter even if it has an undefined value. Default: false.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: false.
+	 * @param allowUndefined - (Optional) Whether to include the query parameter even if it has an `undefined` value. Default: `false`.
+	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	addQueryParameter(name: string, value: StarkQueryParam, allowUndefined?: boolean, allowEmpty?: boolean): this;
@@ -30,8 +30,8 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	 *
 	 * @link StarkQueryParam
 	 * @param params - Object with the query parameters to be added to the request
-	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have undefined values. Default: false.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: false.
+	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
+	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	addQueryParameters(params: { [param: string]: StarkQueryParam }, allowUndefined?: boolean, allowEmpty?: boolean): this;
@@ -41,8 +41,8 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	 *
 	 * @link StarkQueryParam
 	 * @param params - Object with the query parameters to be added to the request
-	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have undefined values. Default: false.
-	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: false.
+	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
+	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
 	 */
 	setQueryParameters(params: { [param: string]: StarkQueryParam }, allowUndefined?: boolean, allowEmpty?: boolean): this;
@@ -62,7 +62,7 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	retry(retryCount: number): this;
 
 	/**
-	 * Returns an instance of the constructed StarkHttpRequest. It should be always the last method to be called.
+	 * Returns an instance of the constructed {@link StarkHttpRequest}. It should be always the last method to be called.
 	 *
 	 * @link StarkHttpRequest
 	 * @returns The constructed request

--- a/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-abstract-base-request-builder.intf.ts
@@ -16,9 +16,8 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Adds a query parameter to the request (if the parameter already exists it will be overwritten)
 	 *
-	 * @link StarkQueryParam
 	 * @param name - Query parameter name
-	 * @param value - Query parameter value
+	 * @param value - `StarkQueryParam` object to be used as the query parameter value
 	 * @param allowUndefined - (Optional) Whether to include the query parameter even if it has an `undefined` value. Default: `false`.
 	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
@@ -28,8 +27,7 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Adds query parameters to the request (adds them to the existing query parameters)
 	 *
-	 * @link StarkQueryParam
-	 * @param params - Object with the query parameters to be added to the request
+	 * @param params - Object containing the `StarkQueryParam` objects to be added to the request
 	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
 	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
@@ -39,8 +37,7 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	/**
 	 * Sets query parameters to the request (all existing query parameters will be lost)
 	 *
-	 * @link StarkQueryParam
-	 * @param params - Object with the query parameters to be added to the request
+	 * @param params - Object containing the `StarkQueryParam` objects to be added to the request
 	 * @param allowUndefined - (Optional) Whether to include the query parameters even if they have `undefined` values. Default: `false`.
 	 * @param allowEmpty - (Optional) Whether to include the query parameter even if it is an empty string. Default: `false`.
 	 * @returns The current builder
@@ -62,9 +59,10 @@ export interface StarkHttpBaseRequestBuilder<T extends StarkResource> {
 	retry(retryCount: number): this;
 
 	/**
-	 * Returns an instance of the constructed {@link StarkHttpRequest}. It should be always the last method to be called.
+	 * Returns an instance of the constructed {@link StarkHttpRequest}.
 	 *
-	 * @link StarkHttpRequest
+	 * **It should be always the last method to be called.**
+	 *
 	 * @returns The constructed request
 	 */
 	build(): StarkHttpRequest<T>;

--- a/packages/stark-core/src/modules/http/builder/http-abstract-fetch-resource-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-abstract-fetch-resource-request-builder.intf.ts
@@ -6,9 +6,8 @@ import { StarkSortItem } from "../entities";
  */
 export interface StarkHttpFetchResourceRequestBuilder {
 	/**
-	 * Adds language codes to the "Accept-Language" header
+	 * Adds {@link StarkLanguage} codes to the "Accept-Language" header
 	 *
-	 * @link StarkLanguage
 	 * @param languages - Language(s) in which the response should be returned
 	 * @returns The current builder
 	 */
@@ -29,9 +28,8 @@ export interface StarkHttpFetchResourceRequestBuilder {
 	addFilterByStyle(style: string): this;
 
 	/**
-	 * Adds a "sort" query parameter to the request
+	 * Adds {@link StarkSortItem} query parameter(s) to the request
 	 *
-	 * @link StarkSortItem
 	 * @param sortItems - Sort parameters to define the order in which the items will be returned
 	 * @returns The current builder
 	 */

--- a/packages/stark-core/src/modules/http/builder/http-abstract-fetch-resource-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-abstract-fetch-resource-request-builder.intf.ts
@@ -8,21 +8,21 @@ export interface StarkHttpFetchResourceRequestBuilder {
 	/**
 	 * Adds {@link StarkLanguage} codes to the "Accept-Language" header
 	 *
-	 * @param languages - Language(s) in which the response should be returned
+	 * @param languages Language(s) in which the response should be returned
 	 * @returns The current builder
 	 */
 	addAcceptedLanguage(...languages: StarkLanguage[]): this;
 
 	/**
 	 * Adds the fields that should be included in the response
-	 * @param fields - Name of the fields to be included
+	 * @param fields Name of the fields to be included
 	 * @returns The current builder
 	 */
 	addFilterByInclude(...fields: string[]): this;
 
 	/**
 	 * Adds the "style" (a label put on a set of fields) that should be included in the response
-	 * @param style - Name of the style to be included
+	 * @param style Name of the style to be included
 	 * @returns The current builder
 	 */
 	addFilterByStyle(style: string): this;
@@ -30,7 +30,7 @@ export interface StarkHttpFetchResourceRequestBuilder {
 	/**
 	 * Adds {@link StarkSortItem} query parameter(s) to the request
 	 *
-	 * @param sortItems - Sort parameters to define the order in which the items will be returned
+	 * @param sortItems Sort parameters to define the order in which the items will be returned
 	 * @returns The current builder
 	 */
 	addSortBy(...sortItems: StarkSortItem[]): this;

--- a/packages/stark-core/src/modules/http/builder/http-create-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-create-request-builder.intf.ts
@@ -3,13 +3,12 @@ import { StarkHttpBaseRequestBuilder } from "./http-abstract-base-request-builde
 import { StarkResource } from "../entities/resource.entity.intf";
 
 /**
- * This StarkHttpCreateRequestBuilder interface describes the different operations supported by Http request builders for resource-creating requests
+ * This interface describes the different operations supported by Http request builders for "resource-creating" requests
  */
 export interface StarkHttpCreateRequestBuilder<T extends StarkResource> extends StarkHttpBaseRequestBuilder<T> {
 	/**
 	 * Adds an "echo" query parameter to the request
 	 *
-	 * @link StarkHttpEchoType
 	 * @param echo - Echo parameter to specify whether the response should contain a response body
 	 * @returns The current builder
 	 */

--- a/packages/stark-core/src/modules/http/builder/http-create-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-create-request-builder.intf.ts
@@ -9,7 +9,7 @@ export interface StarkHttpCreateRequestBuilder<T extends StarkResource> extends 
 	/**
 	 * Adds an "echo" query parameter to the request
 	 *
-	 * @param echo - Echo parameter to specify whether the response should contain a response body
+	 * @param echo Echo parameter to specify whether the response should contain a response body
 	 * @returns The current builder
 	 */
 	echo(echo: StarkHttpEchoType): this;

--- a/packages/stark-core/src/modules/http/builder/http-request-builder.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-request-builder.intf.ts
@@ -21,41 +21,41 @@ import { StarkResource } from "../entities/resource.entity.intf";
 export interface StarkHttpRequestBuilder<T extends StarkResource> {
 	/**
 	 * Gets an instance of a suitable builder to perform a Create request
-	 * @param item - Item to be sent in the Create request
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param item Item to be sent in the Create request
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpCreateRequestBuilder instance
 	 */
 	create(item: T, params?: StarkHttpCreateRequestParams): StarkHttpCreateRequestBuilder<T>;
 
 	/**
 	 * Gets an instance of a suitable builder to perform an Update request
-	 * @param item - Item to be sent in the Update request
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param item Item to be sent in the Update request
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpUpdateRequestBuilder instance
 	 */
 	update(item: T, params?: StarkHttpUpdateRequestParams): StarkHttpUpdateRequestBuilder<T>;
 
 	/**
 	 * Gets an instance of a suitable builder to perform a Delete request
-	 * @param item - Item to be sent in the Delete request
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param item Item to be sent in the Delete request
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpDeleteRequestBuilder instance
 	 */
 	delete(item: T, params?: StarkHttpDeleteRequestParams): StarkHttpDeleteRequestBuilder<T>;
 
 	/**
 	 * Gets an instance of a suitable builder to perform a Get request
-	 * @param uuid - UUID of the item to be fetched by the Get request
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param uuid UUID of the item to be fetched by the Get request
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpGetRequestBuilder instance
 	 */
 	get(uuid: string, params?: StarkHttpGetRequestParams): StarkHttpGetRequestBuilder<T>;
 
 	/**
 	 * Gets an instance of a suitable builder to perform a GetCollection request
-	 * @param limit - Maximum number of items to return
-	 * @param offset - Index at which to begin the extraction of the collection to be returned
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param limit Maximum number of items to return
+	 * @param offset Index at which to begin the extraction of the collection to be returned
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpGetCollectionRequestBuilder instance
 	 */
 	getCollection(limit: number, offset: number, params?: StarkHttpGetCollectionRequestParams): StarkHttpGetCollectionRequestBuilder<T>;
@@ -63,10 +63,10 @@ export interface StarkHttpRequestBuilder<T extends StarkResource> {
 	/**
 	 * Gets an instance of a suitable builder to perform a Search request. Similar to a GetCollection request but the search
 	 * parameters are sent in the request body payload whereas in the GetCollection request they are sent as URL query parameters
-	 * @param criteria - Object containing the search criteria to be sent in the request body payload
-	 * @param limit - Maximum number of items to return
-	 * @param offset - Index at which to begin the extraction of the collection to be returned
-	 * @param params - Object containing additional parameters to construct the request to be sent
+	 * @param criteria Object containing the search criteria to be sent in the request body payload
+	 * @param limit Maximum number of items to return
+	 * @param offset Index at which to begin the extraction of the collection to be returned
+	 * @param params Object containing additional parameters to construct the request to be sent
 	 * @returns StarkHttpSearchRequestBuilder instance
 	 */
 	search(

--- a/packages/stark-core/src/modules/http/builder/http-request-builder.ts
+++ b/packages/stark-core/src/modules/http/builder/http-request-builder.ts
@@ -106,7 +106,7 @@ export class StarkHttpRequestBuilderImpl<T extends StarkResource> implements Sta
 
 		// if the force parameter is not defined or is set to false
 		// then we DO set the If-Match header (i.e., conditional delete)
-		// if force is set to true, the ETag is not given
+		// if force is set to `true`, the ETag is not given
 		// this makes sense in cases where the user states "delete this no matter what", given that the server supports/allows it
 		if (!normalizedParams || normalizedParams.force !== true) {
 			builder.setHeader(StarkHttpHeaders.IF_MATCH, <string>item.etag);

--- a/packages/stark-core/src/modules/http/builder/http-request-parameters.intf.ts
+++ b/packages/stark-core/src/modules/http/builder/http-request-parameters.intf.ts
@@ -1,16 +1,16 @@
 import { StarkSerializable } from "../../../serialization";
 
 /**
- * This interface defines the structure to follow when providing additional parameters to the StarkHttpRequestBuilder.
+ * This interface defines the structure to follow when providing additional parameters via the {@link StarkHttpRequestBuilder}.
  */
 export interface StarkHttpRequestParams {
 	/**
-	 * Whether to allow query parameters with undefined value or not. Default: false.
+	 * Whether to allow query parameters with `undefined` value or not. Default: `false`.
 	 */
 	allowUndefinedQueryParams?: boolean;
 
 	/**
-	 * Whether to allow query parameters with empty value ('') or not. Default: false.
+	 * Whether to allow query parameters with empty value ('') or not. Default: `false`.
 	 */
 	allowEmptyQueryParams?: boolean;
 
@@ -25,7 +25,7 @@ export interface StarkHttpRequestParams {
 	queryParameters?: { [param: string]: string | string[] | undefined };
 
 	/**
-	 * Maximum number of times the request should be retried in case of error before emitting the failure. Default: 0
+	 * Maximum number of times the request should be retried in case of error before emitting the failure. Default: `0`
 	 */
 	retryCount?: number;
 
@@ -36,48 +36,48 @@ export interface StarkHttpRequestParams {
 }
 
 /**
- * Extra parameters to customize the create Http request to be sent.
+ * Extra parameters to customize the `create` Http request to be sent.
  */
 export interface StarkHttpCreateRequestParams extends StarkHttpRequestParams {}
 
 /**
- * Extra parameters to customize the get Http request to be sent.
+ * Extra parameters to customize the `get` Http request to be sent.
  */
 export interface StarkHttpGetRequestParams extends StarkHttpRequestParams {}
 
 /**
- * Extra parameters to customize the update Http request to be sent.
+ * Extra parameters to customize the `update` Http request to be sent.
  */
 export interface StarkHttpUpdateRequestParams extends StarkHttpRequestParams {
 	/**
-	 * When true, the request-type uses HTTP PUT else it uses HTTP POST. Default: false
+	 * When `true`, the request-type uses HTTP PUT else it uses HTTP POST. Default: `false`
 	 */
 	isIdempotent?: boolean;
 }
 
 /**
- * Extra parameters to customize the delete Http request to be sent.
+ * Extra parameters to customize the `delete` Http request to be sent.
  */
 export interface StarkHttpDeleteRequestParams extends StarkHttpRequestParams {
 	/**
-	 * Whether the delete should be enforced or not. Default: false
-	 * When set to true, the ETag value is not passed.
-	 * Only set this to true if it makes sense for the use case and if your back-end allows it!
+	 * Whether the delete should be enforced or not. Default: `false`
+	 * When set to `true`, the ETag value is not passed.
+	 * Only set this to `true` if it makes sense for the use case and if your back-end allows it!
 	 */
 	force?: boolean;
 }
 
 /**
- * Extra parameters to customize the get collection Http request to be sent.
+ * Extra parameters to customize the `getCollection` Http request to be sent.
  */
 export interface StarkHttpGetCollectionRequestParams extends StarkHttpRequestParams {}
 
 /**
- * Extra parameters to customize the search Http request to be sent.
+ * Extra parameters to customize the `search` Http request to be sent.
  */
 export interface StarkHttpSearchRequestParams extends StarkHttpRequestParams {
 	/**
-	 * Whether to allow criteria with empty value ('') or not. Default: false.
+	 * Whether to allow criteria with empty value ('') or not. Default: `false`.
 	 */
 	allowEmptyCriteria?: boolean;
 }

--- a/packages/stark-core/src/modules/http/entities/backend/backend-authentication-types.ts
+++ b/packages/stark-core/src/modules/http/entities/backend/backend-authentication-types.ts
@@ -1,7 +1,7 @@
 /**
- * Authentication type for a given back-end.
- * DO NOT ADD entries in-between others, or the configuration files might get broken (different ordinal value!)
+ * Authentication type for a given {@link StarkBackend}.
  */
+// DO NOT ADD entries in-between others, or the configuration files might get broken (different ordinal value!)
 export enum StarkBackendAuthenticationTypes {
 	COOKIE,
 	PUBLIC,

--- a/packages/stark-core/src/modules/http/entities/backend/backend.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/backend/backend.entity.intf.ts
@@ -5,7 +5,7 @@ import { StarkBackendAuthenticationTypes } from "./backend-authentication-types"
  */
 export interface StarkBackend {
 	/**
-	 * The name of the back-end. Referred to in repositories implementation.
+	 * The name of the back-end. Referred to in the Http repositories implementation.
 	 */
 	name: string;
 
@@ -16,30 +16,32 @@ export interface StarkBackend {
 
 	/**
 	 * Authentication type for that back-end.
-	 * @link StarkBackendAuthenticationTypes
 	 */
 	authenticationType: StarkBackendAuthenticationTypes;
 
 	/**
-	 * Set this to true if fake pre-authentication should be enabled.
-	 * When enabled AND running development mode, Stark will add the authentication headers,
+	 * Set this to `true` if fake pre-authentication should be enabled.
+	 *
+	 * When enabled **and** running development mode, Stark will add the authentication headers,
 	 * that are provided by the client application, to each request.
-	 * The DEV-Authentication headers provide the information expected
+	 * The Dev-Authentication headers provide the information expected
 	 * by the back-end for authentication.
+	 *
 	 * In real environments, infrastructure takes care of this.
-	 * This SHOULD NEVER be enabled for user acceptance or production environments!
+	 *
+	 * **This should never be enabled for user acceptance or production environments!**
 	 */
 	devAuthenticationEnabled: boolean;
 
 	/**
 	 * Prefix for roles. Added to each role when sent to the back-end.
-	 * MUST add the prefix that the back-end expects
+	 * **Must** add the prefix that the back-end expects
 	 * This is necessary to mimic the behavior of the WAF
 	 */
 	devAuthenticationRolePrefix: string;
 
 	/**
-	 * Path of the login resource (optional).
+	 * Path of the login resource.
 	 */
 	loginResource?: string;
 

--- a/packages/stark-core/src/modules/http/entities/error/http-error-base.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/error/http-error-base.entity.intf.ts
@@ -2,7 +2,7 @@ import { StarkError } from "../../../../common/error";
 
 /**
  * The StarkHttpErrorBase class contains all the basic information about the error(s) that are part of the Http
- * error in case of failure of any type of request performed by the Stark Http Service.
+ * error in case of failure of any type of request performed by the {@link StarkHttpService}.
  */
 export interface StarkHttpErrorBase extends StarkError {
 	/**

--- a/packages/stark-core/src/modules/http/entities/error/http-error-detail.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/error/http-error-detail.entity.intf.ts
@@ -2,7 +2,7 @@ import { StarkHttpErrorBase } from "./http-error-base.entity.intf";
 
 /**
  * The StarkHttpErrorDetail class contains all the information about the error(s) that are part of the Http
- * error in case of failure of any type of request performed by the Stark Http Service and it is wrapped in a StarkHttpError.
+ * error in case of failure of any type of request performed by the {@link StarkHttpService} and it is wrapped in a StarkHttpError.
  */
 export interface StarkHttpErrorDetail extends StarkHttpErrorBase {
 	/**

--- a/packages/stark-core/src/modules/http/entities/error/http-error-wrapper.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/error/http-error-wrapper.entity.intf.ts
@@ -2,15 +2,13 @@ import { StarkHttpResponse } from "../response";
 import { StarkHttpError } from "./http-error.entity.intf";
 
 /**
- * This class is used by the Stark Http Service in order to wrap the Http error in
+ * This class is used by the {@link StarkHttpService} in order to wrap the Http error in
  * case of failure of any type of request, either single item or collection request.
  */
 export interface StarkHttpErrorWrapper extends StarkHttpResponse {
 	/**
 	 * Contains all the information about the Http error in case of
-	 * failure of any type of request performed by the Stark Http Service.
-	 *
-	 * @link StarkHttpError
+	 * failure of any type of request performed by the {@link StarkHttpService}.
 	 */
 	httpError: StarkHttpError;
 }

--- a/packages/stark-core/src/modules/http/entities/error/http-error.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/error/http-error.entity.intf.ts
@@ -2,13 +2,12 @@ import { StarkHttpErrorBase } from "./http-error-base.entity.intf";
 import { StarkHttpErrorDetail } from "./http-error-detail.entity.intf";
 
 /**
- * The StarkHttpError class contains all the information about the Http error in case of failure of
- * any type of request performed by the Stark Http Service and it is wrapped in a StarkHttpErrorWrapper.
+ * This class contains all the information about the Http error in case of failure of
+ * any type of request performed by the {@link StarkHttpService} and it is wrapped in a {@link StarkHttpErrorWrapper}.
  */
 export interface StarkHttpError extends StarkHttpErrorBase {
 	/**
-	 * All information about the Http error.
-	 * @link StarkHttpErrorDetail
+	 * An array of {@link StarkHttpErrorDetail} objects containing all the information about the Http error.
 	 */
 	errors: StarkHttpErrorDetail[];
 }

--- a/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
+++ b/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
@@ -8,7 +8,7 @@ import { HttpParameterCodec } from "@angular/common/http";
 export class StarkHttpParameterCodec implements HttpParameterCodec {
 	/**
 	 * Encodes a key
-	 * @param key - key to encode
+	 * @param key - Key to encode
 	 */
 	public encodeKey(key: string): string {
 		return encodeURIComponent(key);
@@ -16,7 +16,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Encodes a value
-	 * @param value - value to encode
+	 * @param value - Value to encode
 	 */
 	public encodeValue(value: string): string {
 		return encodeURIComponent(value);
@@ -24,7 +24,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Decodes a key
-	 * @param key - key to decode
+	 * @param key - Key to decode
 	 */
 	public decodeKey(key: string): string {
 		return decodeURIComponent(key);
@@ -32,7 +32,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Decodes a value
-	 * @param value - value to decode
+	 * @param value - Value to decode
 	 */
 	public decodeValue(value: string): string {
 		return decodeURIComponent(value);

--- a/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
+++ b/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
@@ -1,9 +1,15 @@
 import { HttpParameterCodec } from "@angular/common/http";
 
 /**
- * A custom implementation of HttpParameterCodec (used for encoding / decoding HTTP query parameters).
+ *
+ * A custom implementation of Angular {@link https://v7.angular.io/api/common/http/HttpParameterCodec|HttpParameterCodec} to correctly
+ * encode/decode HTTP query parameters via the {@link StarkHttpService}.
+ *
  * Uses the default JavaScript method `encodeURIComponent` and `decodeURIComponent` for encoding and decoding.
- * @link https://github.com/angular/angular/issues/18261#issuecomment-426383787
+ *
+ * See:
+ * - {@link https://github.com/NationalBankBelgium/stark/issues/1130}
+ * - {@link https://github.com/angular/angular/issues/18261#issuecomment-426383787}
  */
 export class StarkHttpParameterCodec implements HttpParameterCodec {
 	/**

--- a/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
+++ b/packages/stark-core/src/modules/http/entities/http-parameter-codec.ts
@@ -14,7 +14,7 @@ import { HttpParameterCodec } from "@angular/common/http";
 export class StarkHttpParameterCodec implements HttpParameterCodec {
 	/**
 	 * Encodes a key
-	 * @param key - Key to encode
+	 * @param key Key to encode
 	 */
 	public encodeKey(key: string): string {
 		return encodeURIComponent(key);
@@ -22,7 +22,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Encodes a value
-	 * @param value - Value to encode
+	 * @param value Value to encode
 	 */
 	public encodeValue(value: string): string {
 		return encodeURIComponent(value);
@@ -30,7 +30,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Decodes a key
-	 * @param key - Key to decode
+	 * @param key Key to decode
 	 */
 	public decodeKey(key: string): string {
 		return decodeURIComponent(key);
@@ -38,7 +38,7 @@ export class StarkHttpParameterCodec implements HttpParameterCodec {
 
 	/**
 	 * Decodes a value
-	 * @param value - Value to decode
+	 * @param value Value to decode
 	 */
 	public decodeValue(value: string): string {
 		return decodeURIComponent(value);

--- a/packages/stark-core/src/modules/http/entities/http-request.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/http-request.entity.intf.ts
@@ -7,12 +7,11 @@ import { StarkHttpSerializer } from "../serializer";
 export type StarkQueryParam = string | string[] | undefined;
 
 /**
- * This interface describes all the available options of an Http request performed via the StarkHttpService.
+ * This interface describes all the available options of an Http request performed via the {@link StarkHttpService}.
  */
 export interface StarkHttpRequest<P extends StarkResource = StarkResource> {
 	/**
 	 * The backend that the request will target.
-	 * @link StarkBackend
 	 */
 	backend: StarkBackend;
 	/**
@@ -28,14 +27,15 @@ export interface StarkHttpRequest<P extends StarkResource = StarkResource> {
 	 */
 	fieldsToInclude?: string[];
 	/**
-	 * Map containing the headers to be sent with the request. Multiple values for a header are supported.
+	 * Map containing the headers to be sent with the request. **Multiple values for a header are supported.**
 	 */
 	headers: Map<string, string | string[]>;
 	/**
-	 * Map containing the parameters that will be included as query parameters.
+	 * Map containing the {@link StarkQueryParam} objects that will be included as query parameters.
+	 * 
 	 * The query parameters might be `undefined` values in case the `allowUndefinedQueryParams` option is enabled and passed to the corresponding builder.
-	 * If an array of strings is defined as value, then the parameter will be added to the URL for every value in the array.
-	 * @link StarkQueryParam
+	 * 
+	 * **If an array of strings is defined as value, then the parameter will be added to the URL for every value in the array.**
 	 */
 	queryParameters: Map<string, StarkQueryParam>;
 	/**

--- a/packages/stark-core/src/modules/http/entities/http-request.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/http-request.entity.intf.ts
@@ -21,7 +21,6 @@ export interface StarkHttpRequest<P extends StarkResource = StarkResource> {
 	resourcePath: string;
 	/**
 	 * The sort criteria that will be sent along with the request as query parameters.
-	 * @link StarkSortItem
 	 */
 	sortItems?: StarkSortItem[];
 	/**
@@ -34,14 +33,13 @@ export interface StarkHttpRequest<P extends StarkResource = StarkResource> {
 	headers: Map<string, string | string[]>;
 	/**
 	 * Map containing the parameters that will be included as query parameters.
-	 * The query parameters might be undefined values in case the allowUndefinedQueryParams option is enabled and passed to the corresponding builder.
+	 * The query parameters might be `undefined` values in case the `allowUndefinedQueryParams` option is enabled and passed to the corresponding builder.
 	 * If an array of strings is defined as value, then the parameter will be added to the URL for every value in the array.
 	 * @link StarkQueryParam
 	 */
 	queryParameters: Map<string, StarkQueryParam>;
 	/**
 	 * The type of request according to the different CRUD operations.
-	 * @link StarkHttpRequestType
 	 */
 	requestType: StarkHttpRequestType;
 	/**
@@ -50,7 +48,6 @@ export interface StarkHttpRequest<P extends StarkResource = StarkResource> {
 	item?: P | { [param: string]: any };
 	/**
 	 * A serializer class that will perform the serialization/deserialization of the items to be sent/received to/from the backend.
-	 * @link StarkHttpSerializer
 	 */
 	serializer: StarkHttpSerializer<P>;
 	/**

--- a/packages/stark-core/src/modules/http/entities/metadata/collection-metadata.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/metadata/collection-metadata.entity.intf.ts
@@ -4,27 +4,28 @@ import { StarkETags } from "./metadata-etags.entity.intf";
 import { StarkWarnings } from "./metadata-warnings.entity.intf";
 
 /**
- * Stark Collection Metadata
- * Contains all the metadata related to the collection of items in the response of GetCollection or Search request.
+ * Describes all the metadata related to the collection of items in
+ * the response of a request built via the [StarkHttpRequestBuilder getCollection()]{@link StarkHttpRequestBuilder#getCollection} or [StarkHttpRequestBuilder search()]{@link StarkHttpRequestBuilder#search} method.
  */
 export interface StarkCollectionMetadata extends StarkETags, StarkWarnings {
 	/**
-	 * Object containing sorting metadata
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Sorting-Metadata
-	 * @link StarkSortItem
+	 * Object containing sorting metadata.
+	 *
+	 * See {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Sorting-Metadata|NBB REST API Design Guide: Sorting Metadata}
 	 */
 	sortedBy: StarkSortItem[];
 
 	/**
-	 * Object containing pagination metadata
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata#pagination-metadata
-	 * @link StarkPaginationMetadata
+	 * Object containing pagination metadata.
+	 *
+	 * See {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata#pagination-metadata|NBB REST API Design Guide: Pagination Rules and Metadata - pagination metadata}
 	 */
 	pagination: StarkPaginationMetadata;
 
 	/**
-	 * Object containing any other custom metadata (if any)
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata#custom-metadata
+	 * Object containing any other custom metadata (if any).
+	 *
+	 * See {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata#custom-metadata|NBB REST API Design Guide: Pagination Rules and Metadata - custom metadata}
 	 */
 	custom?: object;
 }

--- a/packages/stark-core/src/modules/http/entities/metadata/metadata-etags.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/metadata/metadata-etags.entity.intf.ts
@@ -1,11 +1,14 @@
 /**
- * Interface that describes the etags array to be included in a GetCollection response
+ * Interface that describes the etags array to be included in the response of a request built
+ * via the [StarkHttpRequestBuilder getCollection()]{@link StarkHttpRequestBuilder#getCollection} method.
  */
 export interface StarkETags {
 	/**
-	 * For collection responses only.
-	 * Object containing the mapping between the items in the collection "items" array and the ETag value for each.
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Concurrency-vs-Pagination#metadata
+	 * **For collection responses only.**
+	 *
+	 * Object containing the mapping between the items in the collection `items` array and the ETag value for each.
+	 *
+	 * See {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Concurrency-vs-Pagination#metadata|NBB REST API Design Guide: Concurrency vs Pagination - metadata}
 	 */
 	etags?: { [uuid: string]: string };
 }

--- a/packages/stark-core/src/modules/http/entities/metadata/metadata-sort-item.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/metadata/metadata-sort-item.entity.intf.ts
@@ -1,6 +1,6 @@
 /**
- * The StarkSortItem class contains the different sort criteria for the items contained in the response of a collection request performed by the Stark Http Service.
- * This information is serialized by the service into the request query parameters and deserialized from the response in the StarkCollectionMetadata object.
+ * The StarkSortItem class contains the different sort criteria for the items contained in the response of a collection request performed by the {@link StarkHttpService}.
+ * This information is serialized by the service into the request query parameters and deserialized from the response in the {@link StarkCollectionMetadata} object.
  */
 export interface StarkSortItem {
 	/**
@@ -8,12 +8,12 @@ export interface StarkSortItem {
 	 */
 	field: string;
 	/**
-	 * The order of the sorting on that field: ASC|DESC.
+	 * The order of the sorting on that field: `ASC | DESC`.
 	 */
 	order: string;
 	/**
-	 * The combination of field + order.
-	 * This is the computed value that is sent in the request as query parameter. For example: title+DESC
+	 * The combination of `field + order`.
+	 * This is the computed value that is sent in the request as query parameter. For example: `title+DESC`
 	 */
 	sortValue?: string;
 }

--- a/packages/stark-core/src/modules/http/entities/metadata/metadata-warnings.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/metadata/metadata-warnings.entity.intf.ts
@@ -5,12 +5,13 @@ import { StarkHttpErrorDetail } from "../error";
  */
 export interface StarkWarnings {
 	/**
-	 * Warnings sent by the backend as a result of server-side validations.
+	 * Array of warnings ({@link StarkHttpErrorDetail} objects) sent by the backend as a result of server-side validations.
 	 * Warnings can be included in the resource itself inside a "metadata" object for single item responses or
 	 * in the collection "metadata" object for collection responses.
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Error-handling-Warnings
-	 * @link StarkHttpErrorDetail
+	 *
+	 * See:
+	 * - {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Pagination-Rules-and-metadata|NBB REST API Design Guide: Pagination Rules and Metadata}
+	 * - {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Error-handling-Warnings|NBB REST API Design Guide: Error Handling Warnings}
 	 */
 	warnings?: StarkHttpErrorDetail[];
 }

--- a/packages/stark-core/src/modules/http/entities/resource.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/resource.entity.intf.ts
@@ -1,26 +1,25 @@
 import { StarkSingleItemMetadata } from "./metadata";
 
 /**
- * StarkResource is an interface that describes a Resource.
- * This interface must be implemented by all entities that are related to back-end REST resources.
+ * This interface describes a `Resource` and it must be implemented by all entities that are related to back-end REST resources.
  */
 export interface StarkResource {
 	/**
 	 * The uuid of this item.
-	 * this SHOULD always be the UUID of the resource!
+	 * This **should** always be the UUID of the resource!
 	 */
 	uuid: string;
 
 	/**
 	 * The ETAG of this item.
-	 * this value will be handled by the Stark HTTP API automatically for you
+	 * This value will be handled by the Stark HTTP API automatically for you.
 	 */
 	etag?: string;
 
 	/**
-	 * Optionally, in single item responses only, the backend may return warnings along with the resource itself
-	 * @link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Error-handling-Warnings
-	 * @link StarkSingleItemMetadata
+	 * Optionally, **in single item responses only**, the backend may return warnings along with the resource itself.
+	 *
+	 * See {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide/wiki/Error-handling-Warnings|NBB REST API Design Guide: Error Handling Warnings}
 	 */
 	metadata?: StarkSingleItemMetadata;
 }

--- a/packages/stark-core/src/modules/http/entities/response/collection-response-wrapper.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/response/collection-response-wrapper.entity.intf.ts
@@ -3,12 +3,12 @@ import { StarkResource } from "../resource.entity.intf";
 import { StarkCollectionMetadata } from "../metadata";
 
 /**
- * This class is used by the Stark Http Service in order to wrap the Http response from all requests aimed to return a collection of items.
+ * An implementation class of this interface is used by the {@link StarkHttpService} in order to wrap the 
+ * Http response from all requests aimed to return a collection of items.
  */
 export interface StarkCollectionResponseWrapper<P extends StarkResource> extends StarkResponseWrapper<P[]> {
 	/**
 	 * Holds the metadata related to the collection of items contained in the response.
-	 * @link StarkCollectionMetadata
 	 */
 	metadata: StarkCollectionMetadata;
 }

--- a/packages/stark-core/src/modules/http/entities/response/http-raw-collection-response-data.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/response/http-raw-collection-response-data.intf.ts
@@ -10,7 +10,6 @@ export interface StarkHttpRawCollectionResponseData<P> {
 	items: P[];
 	/**
 	 * Contains all the metadata related to the collection of items in the response.
-	 * @link StarkCollectionMetadata
 	 */
 	metadata: StarkCollectionMetadata;
 }

--- a/packages/stark-core/src/modules/http/entities/response/http-response.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/response/http-response.entity.intf.ts
@@ -5,8 +5,7 @@ import { StarkHttpStatusCodes } from "../../enumerators";
  */
 export interface StarkHttpResponse {
 	/**
-	 * The corresponding status code of the request matching one of the StarkHttpStatusCodes.
-	 * @link StarkHttpStatusCodes
+	 * The corresponding status code of the request matching one of the {@link StarkHttpStatusCodes}.
 	 */
 	starkHttpStatusCode: StarkHttpStatusCodes;
 	/**

--- a/packages/stark-core/src/modules/http/entities/response/response-wrapper.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/response/response-wrapper.entity.intf.ts
@@ -1,11 +1,11 @@
 import { StarkHttpResponse } from "./http-response.entity.intf";
 
 /**
- * This class is used by the Stark Http Service in order to wrap the Http response from all requests aimed to return item(s).
+ * This class is used by the {@link StarkHttpService} in order to wrap the Http response from all requests aimed to return item(s).
  */
-export interface StarkResponseWrapper<T> extends StarkHttpResponse {
+export interface StarkResponseWrapper<DataType> extends StarkHttpResponse {
 	/**
 	 * Holds the data if the Http request was successful.
 	 */
-	data: T;
+	data: DataType;
 }

--- a/packages/stark-core/src/modules/http/entities/response/single-item-response-wrapper.entity.intf.ts
+++ b/packages/stark-core/src/modules/http/entities/response/single-item-response-wrapper.entity.intf.ts
@@ -2,6 +2,6 @@ import { StarkResponseWrapper } from "./response-wrapper.entity.intf";
 import { StarkResource } from "../resource.entity.intf";
 
 /**
- * This class is used by the Stark Http Service in order to wrap the Http response from all requests aimed to return a single item.
+ * This class is used by the {@link StarkHttpService} in order to wrap the Http response from all requests aimed to return a single item.
  */
 export interface StarkSingleItemResponseWrapper<T extends StarkResource> extends StarkResponseWrapper<T> {}

--- a/packages/stark-core/src/modules/http/http.module.ts
+++ b/packages/stark-core/src/modules/http/http.module.ts
@@ -23,7 +23,7 @@ export class StarkHttpModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/http/http.module.ts
+++ b/packages/stark-core/src/modules/http/http.module.ts
@@ -9,8 +9,8 @@ export class StarkHttpModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
 		return {
@@ -21,8 +21,8 @@ export class StarkHttpModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/http/http.module.ts
+++ b/packages/stark-core/src/modules/http/http.module.ts
@@ -8,8 +8,9 @@ import { STARK_HTTP_SERVICE, StarkHttpServiceImpl } from "./services";
 export class StarkHttpModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
@@ -21,7 +22,7 @@ export class StarkHttpModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
+++ b/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
@@ -33,11 +33,11 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Class constructor
-	 * @param starkHttpService The Http Service provided by Stark.
-	 * @param logger The logging service. @link StarkLoggingService.
-	 * @param backend The backend that this HttpRepository will target.
-	 * @param resourcePath The resource path that will be used as default for all the requests performed by this HttpRepository. This will be replaced by the resourcePath provided (if any) in the getRequestBuilder() method.
-	 * @param serializer The serializer that will be attached by default to every StarkHttpRequest sent by this HttpRepository to serialize/deserialize the items to be sent/received to/from the backend.
+	 * @param starkHttpService - The Http Service provided by Stark.
+	 * @param logger - The `StarkLoggingService` instance of the application.
+	 * @param backend - The backend that this HttpRepository will target.
+	 * @param resourcePath - The resource path that will be used as default for all the requests performed by this HttpRepository. This will be replaced by the resourcePath provided (if any) in the getRequestBuilder() method.
+	 * @param serializer - The serializer that will be attached by default to every `StarkHttpRequest` sent by this HttpRepository to serialize/deserialize the items to be sent/received to/from the backend.
 	 */
 	public constructor(
 		protected starkHttpService: StarkHttpService<T>,
@@ -58,8 +58,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to create a resource item.
-	 * @param item - the item to create
-	 * @param params - the parameters used to create the item
+	 * @param item - The item to create
+	 * @param params - The parameters used to create the item
 	 */
 	public create(item: T, params?: StarkHttpCreateRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -71,8 +71,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to update an existing resource item.
-	 * @param item - the item to update
-	 * @param params - the parameters used to update the item
+	 * @param item - The item to update
+	 * @param params - The parameters used to update the item
 	 */
 	public update(item: T, params?: StarkHttpUpdateRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -84,8 +84,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to delete a resource item.
-	 * @param item - the item to delete
-	 * @param params - the parameters used to delete the item
+	 * @param item - The item to delete
+	 * @param params - The parameters used to delete the item
 	 */
 	public delete(item: T, params?: StarkHttpDeleteRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -97,8 +97,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a resource item.
-	 * @param uuid - the uuid of the item to fetch
-	 * @param params - the parameters used to fetch the item
+	 * @param uuid - The uuid of the item to fetch
+	 * @param params - The parameters used to fetch the item
 	 */
 	public get(uuid: string, params?: StarkHttpGetRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -110,9 +110,9 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a range of resource items based on the limit and offset.
-	 * @param limit - the limit to apply to the request
-	 * @param offset - the offset to apply to the request
-	 * @param params - the parameters to apply to the request
+	 * @param limit - The limit to apply to the request
+	 * @param offset - The offset to apply to the request
+	 * @param params - The parameters to apply to the request
 	 */
 	public getCollection(
 		limit: number,
@@ -128,10 +128,10 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a range of resource items that match with the given criteria.
-	 * @param criteria - the criteria of the request
-	 * @param limit - the limit to apply to the request
-	 * @param offset - the offset to apply to the request
-	 * @param params - the parameters to apply to the request
+	 * @param criteria - The criteria of the request
+	 * @param limit - The limit to apply to the request
+	 * @param offset - The offset to apply to the request
+	 * @param params - The parameters to apply to the request
 	 */
 	public search(
 		criteria: { [param: string]: string },

--- a/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
+++ b/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
@@ -33,11 +33,11 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Class constructor
-	 * @param starkHttpService - The Http Service provided by Stark.
-	 * @param logger - The `StarkLoggingService` instance of the application.
-	 * @param backend - The backend that this HttpRepository will target.
-	 * @param resourcePath - The resource path that will be used as default for all the requests performed by this HttpRepository. This will be replaced by the resourcePath provided (if any) in the getRequestBuilder() method.
-	 * @param serializer - The serializer that will be attached by default to every `StarkHttpRequest` sent by this HttpRepository to serialize/deserialize the items to be sent/received to/from the backend.
+	 * @param starkHttpService The Http Service provided by Stark.
+	 * @param logger The `StarkLoggingService` instance of the application.
+	 * @param backend The backend that this HttpRepository will target.
+	 * @param resourcePath The resource path that will be used as default for all the requests performed by this HttpRepository. This will be replaced by the resourcePath provided (if any) in the getRequestBuilder() method.
+	 * @param serializer The serializer that will be attached by default to every `StarkHttpRequest` sent by this HttpRepository to serialize/deserialize the items to be sent/received to/from the backend.
 	 */
 	public constructor(
 		protected starkHttpService: StarkHttpService<T>,
@@ -58,8 +58,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to create a resource item.
-	 * @param item - The item to create
-	 * @param params - The parameters used to create the item
+	 * @param item The item to create
+	 * @param params The parameters used to create the item
 	 */
 	public create(item: T, params?: StarkHttpCreateRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -71,8 +71,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to update an existing resource item.
-	 * @param item - The item to update
-	 * @param params - The parameters used to update the item
+	 * @param item The item to update
+	 * @param params The parameters used to update the item
 	 */
 	public update(item: T, params?: StarkHttpUpdateRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -84,8 +84,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to delete a resource item.
-	 * @param item - The item to delete
-	 * @param params - The parameters used to delete the item
+	 * @param item The item to delete
+	 * @param params The parameters used to delete the item
 	 */
 	public delete(item: T, params?: StarkHttpDeleteRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -97,8 +97,8 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a resource item.
-	 * @param uuid - The uuid of the item to fetch
-	 * @param params - The parameters used to fetch the item
+	 * @param uuid The uuid of the item to fetch
+	 * @param params The parameters used to fetch the item
 	 */
 	public get(uuid: string, params?: StarkHttpGetRequestParams): Observable<StarkSingleItemResponseWrapper<T>> {
 		return this.starkHttpService.executeSingleItemRequest(
@@ -110,9 +110,9 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a range of resource items based on the limit and offset.
-	 * @param limit - The limit to apply to the request
-	 * @param offset - The offset to apply to the request
-	 * @param params - The parameters to apply to the request
+	 * @param limit The limit to apply to the request
+	 * @param offset The offset to apply to the request
+	 * @param params The parameters to apply to the request
 	 */
 	public getCollection(
 		limit: number,
@@ -128,10 +128,10 @@ export abstract class AbstractStarkHttpRepository<T extends StarkResource> {
 
 	/**
 	 * Perform an Http request to fetch a range of resource items that match with the given criteria.
-	 * @param criteria - The criteria of the request
-	 * @param limit - The limit to apply to the request
-	 * @param offset - The offset to apply to the request
-	 * @param params - The parameters to apply to the request
+	 * @param criteria The criteria of the request
+	 * @param limit The limit to apply to the request
+	 * @param offset The offset to apply to the request
+	 * @param params The parameters to apply to the request
 	 */
 	public search(
 		criteria: { [param: string]: string },

--- a/packages/stark-core/src/modules/http/serializer/http-discriminator-serializer.ts
+++ b/packages/stark-core/src/modules/http/serializer/http-discriminator-serializer.ts
@@ -19,8 +19,8 @@ export class StarkHttpDiscriminatorSerializer<T extends StarkResource> extends S
 
 	/**
 	 * Constructor for StarkHttpDiscriminatorSerializer
-	 * @param discriminatorProperty - The discriminator property
-	 * @param typesMap - Map of types based on the discriminator property value
+	 * @param discriminatorProperty The discriminator property
+	 * @param typesMap Map of types based on the discriminator property value
 	 */
 	public constructor(discriminatorProperty: string, typesMap: Map<any, StarkSerializable>) {
 		super();

--- a/packages/stark-core/src/modules/http/serializer/http-serializer.intf.ts
+++ b/packages/stark-core/src/modules/http/serializer/http-serializer.intf.ts
@@ -2,11 +2,12 @@ import { HttpResponse } from "@angular/common/http";
 import { StarkHttpRawCollectionResponseData, StarkHttpRequest, StarkResource } from "../entities";
 
 /**
- * This is the base interface for entities' serializers used mainly by the HTTP Service.
+ * This is the base interface for entities' serializers used mainly by the {@link StarkHttpService}.
  *
- * ResourceType type that this serializer handles.
- * RequestType, defaults to StarkHttpRequest
- * ResponseType, defaults to angular IHttpResponse
+ * It is a generic interface defined by these types:
+ * - `ResourceType`: type that this serializer handles.
+ * - `RequestType`: defaults to {@link StarkHttpRequest}
+ * - `ResponseType`: defaults to the Angular {@link https://v7.angular.io/api/common/http/HttpResponse|HttpResponse}
  */
 export interface StarkHttpSerializer<
 	ResourceType extends StarkResource,

--- a/packages/stark-core/src/modules/http/serializer/http-serializer.intf.ts
+++ b/packages/stark-core/src/modules/http/serializer/http-serializer.intf.ts
@@ -17,8 +17,8 @@ export interface StarkHttpSerializer<
 	/**
 	 * Serialize the given resource entity into an object or a string
 	 *
-	 * @param resource - The entity to serialize
-	 * @param request - Optional request object
+	 * @param resource The entity to serialize
+	 * @param request Optional request object
 	 *
 	 * @returns The serialized form of the provided resource
 	 */
@@ -27,9 +27,9 @@ export interface StarkHttpSerializer<
 	/**
 	 * Deserialize provided string or object into the corresponding resource entity
 	 *
-	 * @param raw - The raw format to deserialize from
-	 * @param request - Optional request object
-	 * @param response - Optional response object
+	 * @param raw The raw format to deserialize from
+	 * @param request Optional request object
+	 * @param response Optional response object
 	 *
 	 * @returns The entity instance created out of the deserialization process.
 	 */

--- a/packages/stark-core/src/modules/http/serializer/http-serializer.ts
+++ b/packages/stark-core/src/modules/http/serializer/http-serializer.ts
@@ -26,7 +26,7 @@ export class StarkHttpSerializerImpl<T extends StarkResource> implements StarkHt
 
 	/**
 	 * Serialize the given resource entity into an object or a string.
-	 * @param resource - the resource to serialize
+	 * @param resource - The resource to serialize
 	 */
 	public serialize(resource: T): string | object {
 		return Serialize(resource, this.getType(resource));
@@ -34,7 +34,7 @@ export class StarkHttpSerializerImpl<T extends StarkResource> implements StarkHt
 
 	/**
 	 * Deserialize provided string or object into the corresponding resource entity.
-	 * @param raw - the raw string or object to deserialize
+	 * @param raw - The raw string or object to deserialize
 	 */
 	public deserialize(raw: string | object): T {
 		return Deserialize(raw, this.getType(raw));

--- a/packages/stark-core/src/modules/http/serializer/http-serializer.ts
+++ b/packages/stark-core/src/modules/http/serializer/http-serializer.ts
@@ -18,7 +18,7 @@ export class StarkHttpSerializerImpl<T extends StarkResource> implements StarkHt
 
 	/**
 	 * Class constructor
-	 * @param type - Default Type Serializable
+	 * @param type Default Type Serializable
 	 */
 	public constructor(type?: StarkSerializable) {
 		this._type = type;
@@ -26,7 +26,7 @@ export class StarkHttpSerializerImpl<T extends StarkResource> implements StarkHt
 
 	/**
 	 * Serialize the given resource entity into an object or a string.
-	 * @param resource - The resource to serialize
+	 * @param resource The resource to serialize
 	 */
 	public serialize(resource: T): string | object {
 		return Serialize(resource, this.getType(resource));
@@ -34,7 +34,7 @@ export class StarkHttpSerializerImpl<T extends StarkResource> implements StarkHt
 
 	/**
 	 * Deserialize provided string or object into the corresponding resource entity.
-	 * @param raw - The raw string or object to deserialize
+	 * @param raw The raw string or object to deserialize
 	 */
 	public deserialize(raw: string | object): T {
 		return Deserialize(raw, this.getType(raw));

--- a/packages/stark-core/src/modules/http/services/http.service.intf.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.intf.ts
@@ -24,14 +24,14 @@ export interface StarkHttpService<T extends StarkResource> {
 
 	/**
 	 * Executes {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequests} to fetch a single resource
-	 * @param request - The `HttpRequest` to be executed
+	 * @param request The `HttpRequest` to be executed
 	 * @returns Observable that will emit the `StarkSingleItemResponseWrapper`
 	 */
 	executeSingleItemRequest(request: StarkHttpRequest): Observable<StarkSingleItemResponseWrapper<T>>;
 
 	/**
 	 * Executes {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequests} to fetch an array of resources
-	 * @param request - The `HttpRequest` to be executed
+	 * @param request The `HttpRequest` to be executed
 	 * @returns Observable that will emit the `StarkCollectionResponseWrapper`
 	 */
 	executeCollectionRequest(request: StarkHttpRequest): Observable<StarkCollectionResponseWrapper<T>>;

--- a/packages/stark-core/src/modules/http/services/http.service.intf.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.intf.ts
@@ -8,32 +8,31 @@ import { Observable } from "rxjs";
  */
 export const starkHttpServiceName = "StarkHttpService";
 /**
- * The InjectionToken version of the service name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkHttpService}
  */
 export const STARK_HTTP_SERVICE: InjectionToken<StarkHttpService<any>> = new InjectionToken<StarkHttpService<any>>(starkHttpServiceName);
 
 /**
  * Stark Http Service
- * Service to make HTTP calls in compliance with the guidelines from the NBB REST API Design Guide.
+ * Service to make HTTP calls in compliance with the guidelines from the {@link https://github.com/NationalBankBelgium/REST-API-Design-Guide|NBB REST API Design Guide}.
  */
 export interface StarkHttpService<T extends StarkResource> {
 	/**
-	 * Gets the core Angular HTTP API (HttpClient)
-	 * @returns Angular Http client
+	 * Gets the core Angular HTTP API ({@link https://v7.angular.io/api/common/http/HttpClient|HttpClient})
 	 */
 	readonly rawHttpClient: HttpClient;
 
 	/**
-	 * Executes requests to fetch a single resource
-	 * @param request - The HTTP request to be executed
-	 * @returns Observable that will emit the single item response wrapper
+	 * Executes {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequests} to fetch a single resource
+	 * @param request - The `HttpRequest` to be executed
+	 * @returns Observable that will emit the `StarkSingleItemResponseWrapper`
 	 */
 	executeSingleItemRequest(request: StarkHttpRequest): Observable<StarkSingleItemResponseWrapper<T>>;
 
 	/**
-	 * Executes requests to fetch an array of resources
-	 * @param request - The HTTP request to be executed
-	 * @returns Observable that will emit the collection response wrapper
+	 * Executes {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequests} to fetch an array of resources
+	 * @param request - The `HttpRequest` to be executed
+	 * @returns Observable that will emit the `StarkCollectionResponseWrapper`
 	 */
 	executeCollectionRequest(request: StarkHttpRequest): Observable<StarkCollectionResponseWrapper<T>>;
 }

--- a/packages/stark-core/src/modules/http/services/http.service.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:completed-docs*/
 import { Deserialize, Serialize } from "cerialize";
 import { Observable, throwError, timer } from "rxjs";
-// FIXME Adapt mergeMap code --> See: https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md#howto-result-selector-migration
+// FIXME Adapt mergeMap code --> See: https://github.com/ReactiveX/rxjs/blob/6.x/docs_app/content/guide/v6/migration.md#howto-result-selector-migration
 import { catchError, map, mergeMap, retryWhen } from "rxjs/operators";
 import { Inject, Injectable } from "@angular/core";
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from "@angular/common/http";
@@ -27,7 +27,6 @@ import cloneDeep from "lodash-es/cloneDeep";
 
 /**
  * @ignore
- * Service to make HTTP calls in compliance with the guidelines from the NBB REST API Design Guide.
  */
 @Injectable()
 export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpService<P> {
@@ -54,7 +53,7 @@ export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpS
 		request = this.addCorrelationIdentifierHeader(request);
 
 		// IMPORTANT: In Angular2+ HTTP service subscribing multiple times will actually do multiple requests
-		// see https://angular.io/guide/http#always-subscribe
+		// see https://v7.angular.io/guide/http#always-subscribe
 		let httpResponse$: Observable<HttpResponse<P>> | undefined;
 
 		switch (request.requestType) {
@@ -96,7 +95,7 @@ export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpS
 		request = this.addCorrelationIdentifierHeader(request);
 
 		// IMPORTANT: In Angular2+ HTTP service subscribing multiple times will actually do multiple requests
-		// see https://angular.io/guide/http#always-subscribe
+		// see https://v7.angular.io/guide/http#always-subscribe
 		let httpResponse$: Observable<HttpResponse<StarkHttpRawCollectionResponseData<P>>> | undefined;
 
 		switch (request.requestType) {

--- a/packages/stark-core/src/modules/http/services/http.service.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.ts
@@ -122,7 +122,7 @@ export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpS
 	/**
 	 * remove the etag before executing the request
 	 * We have to remove it otherwise it'll be serialized and cause issues on the back-end
-	 * @param request - The request object to modify
+	 * @param request The request object to modify
 	 * @returns The modified request object
 	 */
 	public removeETagFromRequestItem(request: StarkHttpRequest<P>): StarkHttpRequest<P> {
@@ -140,7 +140,7 @@ export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpS
 
 	/**
 	 * add authentication headers necessary for non-production environments
-	 * @param request - The request object to modify
+	 * @param request The request object to modify
 	 * @returns The modified request object
 	 */
 	public addDevAuthenticationHeaders(request: StarkHttpRequest<P>): StarkHttpRequest<P> {
@@ -158,7 +158,7 @@ export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpS
 
 	/**
 	 * add header for activity correlation
-	 * @param request - The request object to modify
+	 * @param request The request object to modify
 	 * @returns The modified request object
 	 */
 	public addCorrelationIdentifierHeader(request: StarkHttpRequest<P>): StarkHttpRequest<P> {

--- a/packages/stark-core/src/modules/logging/actions/logging.actions.ts
+++ b/packages/stark-core/src/modules/logging/actions/logging.actions.ts
@@ -21,7 +21,7 @@ export class StarkSetLoggingApplicationId implements Action {
 
 	/**
 	 * Class constructor
-	 * @param applicationId - The id of the application
+	 * @param applicationId The id of the application
 	 */
 	public constructor(public applicationId: string) {}
 }
@@ -37,7 +37,7 @@ export class StarkLogMessageAction implements Action {
 
 	/**
 	 * Class constructor
-	 * @param message - The message to log
+	 * @param message The message to log
 	 */
 	public constructor(public message: StarkLogMessage) {}
 }
@@ -53,7 +53,7 @@ export class StarkFlushLogMessages implements Action {
 
 	/**
 	 * Class constructor
-	 * @param numberOfMessagesToFlush - The number of messages to flush
+	 * @param numberOfMessagesToFlush The number of messages to flush
 	 */
 	public constructor(public numberOfMessagesToFlush: number) {}
 }

--- a/packages/stark-core/src/modules/logging/actions/logging.actions.ts
+++ b/packages/stark-core/src/modules/logging/actions/logging.actions.ts
@@ -16,13 +16,12 @@ export enum StarkLoggingActionTypes {
 export class StarkSetLoggingApplicationId implements Action {
 	/**
 	 * The type of action
-	 * @link StarkLoggingActionTypes
 	 */
 	public readonly type: StarkLoggingActionTypes.SET_LOGGING_APPLICATION_ID = StarkLoggingActionTypes.SET_LOGGING_APPLICATION_ID;
 
 	/**
 	 * Class constructor
-	 * @param applicationId - the id of the application
+	 * @param applicationId - The id of the application
 	 */
 	public constructor(public applicationId: string) {}
 }
@@ -33,13 +32,12 @@ export class StarkSetLoggingApplicationId implements Action {
 export class StarkLogMessageAction implements Action {
 	/**
 	 * The type of action
-	 * @link StarkLoggingActionTypes
 	 */
 	public readonly type: StarkLoggingActionTypes.LOG_MESSAGE = StarkLoggingActionTypes.LOG_MESSAGE;
 
 	/**
 	 * Class constructor
-	 * @param message - the message to log
+	 * @param message - The message to log
 	 */
 	public constructor(public message: StarkLogMessage) {}
 }
@@ -50,13 +48,12 @@ export class StarkLogMessageAction implements Action {
 export class StarkFlushLogMessages implements Action {
 	/**
 	 * The type of action
-	 * @link StarkLoggingActionTypes
 	 */
 	public readonly type: StarkLoggingActionTypes.FLUSH_LOG = StarkLoggingActionTypes.FLUSH_LOG;
 
 	/**
 	 * Class constructor
-	 * @param numberOfMessagesToFlush - the number of messages to flush
+	 * @param numberOfMessagesToFlush - The number of messages to flush
 	 */
 	public constructor(public numberOfMessagesToFlush: number) {}
 }

--- a/packages/stark-core/src/modules/logging/actions/logging.actions.ts
+++ b/packages/stark-core/src/modules/logging/actions/logging.actions.ts
@@ -2,7 +2,7 @@ import { Action } from "@ngrx/store";
 import { StarkLogMessage } from "../entities";
 
 /**
- * Actions related to stark logging service
+ * Actions related to {@link StarkLoggingService}
  */
 export enum StarkLoggingActionTypes {
 	SET_LOGGING_APPLICATION_ID = "[StarkLogging] Set Logging Application Id",

--- a/packages/stark-core/src/modules/logging/entities/log-message.entity.intf.ts
+++ b/packages/stark-core/src/modules/logging/entities/log-message.entity.intf.ts
@@ -6,25 +6,23 @@ import { StarkError } from "../../../common/error";
  */
 export interface StarkLogMessage {
 	/**
-	 * the timestamp of the message
+	 * The timestamp of the message
 	 */
 	timestamp: string;
 	/**
-	 * the log message
+	 * The log message
 	 */
 	message: string;
 	/**
-	 * the type of message (debug, warn, info,...)
-	 * @link StarkLogMessageType
+	 * The type of message (debug, warn, info,...)
 	 */
 	type: StarkLogMessageType;
 	/**
-	 * the correlation id of the log message
+	 * The correlation id of the log message
 	 */
 	correlationId: string;
 	/**
-	 * the (optional) error linked to the log message
-	 * @link StarkError
+	 * The error linked to the log message
 	 */
 	error?: StarkError;
 }

--- a/packages/stark-core/src/modules/logging/entities/logging.entity.intf.ts
+++ b/packages/stark-core/src/modules/logging/entities/logging.entity.intf.ts
@@ -5,16 +5,15 @@ import { StarkLogMessage } from "./log-message.entity.intf";
  */
 export interface StarkLogging {
 	/**
-	 * the uuid of the entity
+	 * The `uuid` of the entity
 	 */
 	uuid: string;
 	/**
-	 * the id of the application
+	 * The id of the application
 	 */
 	applicationId: string;
 	/**
-	 * the messages being logged
-	 * @link StarkLogMessage
+	 * The {@link StarkLogMessage} objects being logged
 	 */
 	messages: StarkLogMessage[];
 }

--- a/packages/stark-core/src/modules/logging/logging.module.ts
+++ b/packages/stark-core/src/modules/logging/logging.module.ts
@@ -9,8 +9,9 @@ import { STARK_LOGGING_SERVICE, StarkLoggingServiceImpl } from "./services";
 export class StarkLoggingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
@@ -22,7 +23,7 @@ export class StarkLoggingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/logging/logging.module.ts
+++ b/packages/stark-core/src/modules/logging/logging.module.ts
@@ -10,8 +10,8 @@ export class StarkLoggingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
 		return {
@@ -22,8 +22,8 @@ export class StarkLoggingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/logging/logging.module.ts
+++ b/packages/stark-core/src/modules/logging/logging.module.ts
@@ -24,7 +24,7 @@ export class StarkLoggingModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/logging/reducers/index.ts
+++ b/packages/stark-core/src/modules/logging/reducers/index.ts
@@ -4,27 +4,27 @@ import { StarkLoggingActions } from "../actions";
 import { loggingReducer } from "./logging.reducer";
 
 /**
- * We define part of the state assigned to the logging module
+ * Defines the part of the state assigned to the {@link StarkLoggingModule}
  */
 export interface StarkLoggingState {
 	/**
-	 * The logging property
+	 * State corresponding to the {@link StarkLoggingModule}
 	 */
 	logging: StarkLogging;
 }
 
 /**
- * We assign a reducer to our logging property
+ * Reducers assigned to the each property of the {@link StarkLoggingModule}'s state
  */
 export const starkLoggingReducers: ActionReducerMap<StarkLoggingState, StarkLoggingActions> = {
 	/**
-	 * the reducer is assigned to our property
+	 * Reducer assigned to the state's `logging` property
 	 */
 	logging: loggingReducer
 };
 
 /**
- * The selector will return the part of the state assigned to the logging when called
+ * NGRX Selector for the {@link StarkLoggingModule}'s state
  */
 export const selectStarkLogging: MemoizedSelector<object, StarkLogging> = createSelector(
 	createFeatureSelector<StarkLoggingState>("StarkLogging"),

--- a/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
+++ b/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
@@ -8,21 +8,21 @@ export const starkLoggingStoreKey = "starkLogging";
 
 /**
  * Defines the initial state of the reducer
- * @link StarkLogging
  */
-const INITIAL_STATE: Readonly<StarkLogging> = {
+const INITIAL_LOGGING_STATE: Readonly<StarkLogging> = {
 	uuid: "",
 	applicationId: "",
 	messages: []
 };
 
 /**
- * Definition of the logging reducer.
+ * Definition of the `logging` reducer.
  * @param state - The state of the reducer
  * @param action - The action to perform
+ * @returns The new `StarkLogging` state
  */
 export function loggingReducer(
-	state: Readonly<StarkLogging> = INITIAL_STATE,
+	state: Readonly<StarkLogging> = INITIAL_LOGGING_STATE,
 	action: Readonly<StarkLoggingActions>
 ): Readonly<StarkLogging> {
 	// the new state will be calculated from the data coming in the actions

--- a/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
+++ b/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
@@ -17,8 +17,8 @@ const INITIAL_LOGGING_STATE: Readonly<StarkLogging> = {
 
 /**
  * Definition of the `logging` reducer.
- * @param state - The state of the reducer
- * @param action - The action to perform
+ * @param state The state of the reducer
+ * @param action The action to perform
  * @returns The new `StarkLogging` state
  */
 export function loggingReducer(

--- a/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
+++ b/packages/stark-core/src/modules/logging/reducers/logging.reducer.ts
@@ -18,8 +18,8 @@ const INITIAL_STATE: Readonly<StarkLogging> = {
 
 /**
  * Definition of the logging reducer.
- * @param state - the state of the reducer
- * @param action - the action to perform
+ * @param state - The state of the reducer
+ * @param action - The action to perform
  */
 export function loggingReducer(
 	state: Readonly<StarkLogging> = INITIAL_STATE,

--- a/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
@@ -6,7 +6,7 @@ import { StarkError } from "../../../common/error";
  */
 export const starkLoggingServiceName = "StarkLoggingService";
 /**
- * The InjectionToken version of the service name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkLoggingService}
  */
 export const STARK_LOGGING_SERVICE: InjectionToken<StarkLoggingService> = new InjectionToken<StarkLoggingService>(starkLoggingServiceName);
 
@@ -22,7 +22,7 @@ export interface StarkLoggingService {
 	readonly correlationId: string;
 
 	/**
-	 * The name that will be used to add the CorrelationId to the http headers
+	 * The name that will be used to add the `CorrelationId` to the http headers
 	 */
 	readonly correlationIdHttpHeaderName: string;
 
@@ -33,28 +33,29 @@ export interface StarkLoggingService {
 
 	/**
 	 * Logs debug messages to be used only in development to track issues.
-	 * The debug messages are only logged (and afterwards stored in the Redux store) only when the debugLoggingEnabled configuration setting from the StarkApplicationConfig is set to true.
-	 * @param args - the arguments to log
+	 * The debug messages are only logged (and afterwards stored in the Redux store) only when the `debugLoggingEnabled` configuration
+	 * setting from the {@link StarkApplicationConfig} is set to `true`.
+	 * @param args - The arguments to log
 	 */
 	debug(...args: any[]): void;
 
 	/**
 	 * Logs information messages. These messages are also stored in the Redux store.
-	 * @param args - the arguments to log
+	 * @param args - The arguments to log
 	 */
 	info(...args: any[]): void;
 
 	/**
 	 * Logs warning messages. Warning messages can, for instance, indicate a non blocking problem in the software. These messages are also stored in the Redux store.
-	 * @param args - the arguments to log
+	 * @param args - The arguments to log
 	 */
 	warn(...args: any[]): void;
 
 	/**
 	 * Logs error messages. Error messages should be logged when there was an unexpected error while executing the code.
 	 * They are typically logged in the catch method of a try-catch block. These messages are also stored in the Redux store.
-	 * @param message - the message to log
-	 * @param error - the error to log
+	 * @param message - The message to log
+	 * @param error - The error to log
 	 */
 	error(message: string, error?: StarkError | Error): void;
 }

--- a/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
@@ -36,27 +36,27 @@ export interface StarkLoggingService {
 	 * Logs debug messages to be used only in development to track issues.
 	 * The debug messages are only logged (and afterwards stored in the Redux store) only when the `debugLoggingEnabled` configuration
 	 * setting from the {@link StarkApplicationConfig} is set to `true`.
-	 * @param args - The arguments to log
+	 * @param args The arguments to log
 	 */
 	debug(...args: any[]): void;
 
 	/**
 	 * Logs information messages. These messages are also stored in the Redux store.
-	 * @param args - The arguments to log
+	 * @param args The arguments to log
 	 */
 	info(...args: any[]): void;
 
 	/**
 	 * Logs warning messages. Warning messages can, for instance, indicate a non blocking problem in the software. These messages are also stored in the Redux store.
-	 * @param args - The arguments to log
+	 * @param args The arguments to log
 	 */
 	warn(...args: any[]): void;
 
 	/**
 	 * Logs error messages. Error messages should be logged when there was an unexpected error while executing the code.
 	 * They are typically logged in the catch method of a try-catch block. These messages are also stored in the Redux store.
-	 * @param message - The message to log
-	 * @param error - The error to log
+	 * @param message The message to log
+	 * @param error The error to log
 	 */
 	error(message: string, error?: StarkError | Error): void;
 }

--- a/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.intf.ts
@@ -16,8 +16,9 @@ export const STARK_LOGGING_SERVICE: InjectionToken<StarkLoggingService> = new In
  */
 export interface StarkLoggingService {
 	/**
-	 * Gets the current correlationId. In fact when the logging service is created, it gets a unique correlation Id.
-	 * This value can be used while displaying a generic error message.
+	 * Gets the current `correlationId`. This value can be used while displaying a generic error message.
+	 * 
+	 * **When the logging service is created, it gets a unique correlation Id.**
 	 */
 	readonly correlationId: string;
 

--- a/packages/stark-core/src/modules/logging/services/logging.service.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.ts
@@ -19,8 +19,14 @@ import { StarkError, StarkErrorImpl } from "../../../common/error";
 import { StarkConfigurationUtil } from "../../../util/configuration.util";
 import noop from "lodash-es/noop";
 
+/**
+ * @ignore
+ */
 const xsrfServiceNotFound: "not provided" = "not provided";
 
+/**
+ * @ignore
+ */
 @Injectable()
 export class StarkLoggingServiceImpl implements StarkLoggingService {
 	private backend!: StarkBackend;
@@ -230,7 +236,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 	/**
 	 * Returns the specified window console method if it exists (debug, warn, info, error, trace),
 	 * otherwise returns console.log or empty function
-	 * @param type Type of console to be used: info, debug, warn, error, trace
+	 * @param type - Type of console to be used: info, debug, warn, error, trace
 	 */
 	protected getConsole(type: string): Function {
 		const console: any = window && window.console ? window.console : {};
@@ -251,7 +257,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 
 	/**
 	 * Gets the StarkXSRFService from the Injector (this is tried only once).
-	 * It returns 'undefined' if the service is not found (the XSRF module is not imported in the app).
+	 * It returns `undefined` if the service is not found (the XSRF module is not imported in the app).
 	 */
 	private get xsrfService(): StarkXSRFService | undefined {
 		if (typeof this._xsrfService === "undefined") {

--- a/packages/stark-core/src/modules/logging/services/logging.service.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.ts
@@ -236,7 +236,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 	/**
 	 * Returns the specified window console method if it exists (debug, warn, info, error, trace),
 	 * otherwise returns console.log or empty function
-	 * @param type - Type of console to be used: info, debug, warn, error, trace
+	 * @param type Type of console to be used: info, debug, warn, error, trace
 	 */
 	protected getConsole(type: string): Function {
 		const console: any = window && window.console ? window.console : {};

--- a/packages/stark-core/src/modules/routing/actions/routing.actions.ts
+++ b/packages/stark-core/src/modules/routing/actions/routing.actions.ts
@@ -21,15 +21,14 @@ export enum StarkRoutingActionTypes {
 export class StarkNavigate implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.NAVIGATE = StarkRoutingActionTypes.NAVIGATE;
 
 	/**
 	 * Class constructor
-	 * @param currentState - name of the current state before the navigation starts.
-	 * @param newState - name of the state to be navigated to.
-	 * @param params - state params object to be passed to the navigated state.
+	 * @param currentState - Name of the current state before the navigation starts.
+	 * @param newState - Name of the state to be navigated to.
+	 * @param params - State params object to be passed to the navigated state.
 	 * @param options - Transition options object to change the behavior of the transition.
 	 */
 	public constructor(
@@ -48,15 +47,14 @@ export class StarkNavigate implements Action {
 export class StarkNavigateSuccess implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.NAVIGATE_SUCCESS = StarkRoutingActionTypes.NAVIGATE_SUCCESS;
 
 	/**
 	 * Class constructor
-	 * @param previousState - name of the initial state where the navigation was started.
-	 * @param currentState - name of the state that was navigated to.
-	 * @param params - state params object that was passed to the navigated state.
+	 * @param previousState - Name of the initial state where the navigation was started.
+	 * @param currentState - Name of the state that was navigated to.
+	 * @param params - State params object that was passed to the navigated state.
 	 */
 	public constructor(public previousState: string, public currentState: string, public params?: RawParams) {}
 }
@@ -69,16 +67,15 @@ export class StarkNavigateSuccess implements Action {
 export class StarkNavigateFailure implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.NAVIGATE_FAILURE = StarkRoutingActionTypes.NAVIGATE_FAILURE;
 
 	/**
 	 * Class constructor
-	 * @param currentState - name of the current state before the navigation started.
-	 * @param newState - name of the state tried to be navigated to.
-	 * @param params - state params object passed to the navigated state.
-	 * @param error - the error describing the reason of the navigation failure.
+	 * @param currentState - Name of the current state before the navigation started.
+	 * @param newState - Name of the state tried to be navigated to.
+	 * @param params - State params object passed to the navigated state.
+	 * @param error - The error describing the reason of the navigation failure.
 	 */
 	public constructor(public currentState: string, public newState: string, public params: RawParams, public error: string) {}
 }
@@ -90,16 +87,15 @@ export class StarkNavigateFailure implements Action {
 export class StarkNavigateRejection implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.NAVIGATE_REJECTION = StarkRoutingActionTypes.NAVIGATE_REJECTION;
 
 	/**
 	 * Class constructor
-	 * @param currentState - name of the current state before the navigation started.
-	 * @param newState - name of the state tried to be navigated to.
-	 * @param params - state params object passed to the navigated state.
-	 * @param reason - the reason describing why the navigation was rejected. This is normally a reason already known by the developer.
+	 * @param currentState - Name of the current state before the navigation started.
+	 * @param newState - Name of the state tried to be navigated to.
+	 * @param params - State params object passed to the navigated state.
+	 * @param reason - The reason describing why the navigation was rejected. This is normally a reason already known by the developer.
 	 */
 	public constructor(public currentState: string, public newState: string, public params: RawParams, public reason: string) {}
 }
@@ -110,8 +106,7 @@ export class StarkNavigateRejection implements Action {
  */
 export class StarkNavigationHistoryLimitReached implements Action {
 	/**
-	 * Defines the type of NGRX action to perform.
-	 * @link StarkRoutingActionTypes
+	 * The action type
 	 */
 	public readonly type: StarkRoutingActionTypes.NAVIGATION_HISTORY_LIMIT_REACHED =
 		StarkRoutingActionTypes.NAVIGATION_HISTORY_LIMIT_REACHED;
@@ -123,13 +118,12 @@ export class StarkNavigationHistoryLimitReached implements Action {
 export class StarkReload implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.RELOAD = StarkRoutingActionTypes.RELOAD;
 
 	/**
 	 * Class constructor
-	 * @param state - name of the state to be reloaded.
+	 * @param state - Name of the state to be reloaded.
 	 */
 	public constructor(public state: string) {}
 }
@@ -142,14 +136,13 @@ export class StarkReload implements Action {
 export class StarkReloadSuccess implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.RELOAD_SUCCESS = StarkRoutingActionTypes.RELOAD_SUCCESS;
 
 	/**
 	 * Class constructor
 	 * @param state -  name of the state that was reloaded.
-	 * @param params - state params object passed to the reloaded state.
+	 * @param params - State params object passed to the reloaded state.
 	 */
 	public constructor(public state: string, public params: RawParams) {}
 }
@@ -161,14 +154,13 @@ export class StarkReloadSuccess implements Action {
 export class StarkReloadFailure implements Action {
 	/**
 	 * The action type
-	 * @link StarkRoutingActionTypes
 	 */
 	public readonly type: StarkRoutingActionTypes.RELOAD_FAILURE = StarkRoutingActionTypes.RELOAD_FAILURE;
 
 	/**
 	 * Class constructor
-	 * @param state - name of the state tried to be reloaded.
-	 * @param params - state params object passed to the reloaded state.
+	 * @param state - Name of the state tried to be reloaded.
+	 * @param params - State params object passed to the reloaded state.
 	 */
 	public constructor(public state: string, public params: RawParams) {}
 }

--- a/packages/stark-core/src/modules/routing/actions/routing.actions.ts
+++ b/packages/stark-core/src/modules/routing/actions/routing.actions.ts
@@ -26,10 +26,10 @@ export class StarkNavigate implements Action {
 
 	/**
 	 * Class constructor
-	 * @param currentState - Name of the current state before the navigation starts.
-	 * @param newState - Name of the state to be navigated to.
-	 * @param params - State params object to be passed to the navigated state.
-	 * @param options - Transition options object to change the behavior of the transition.
+	 * @param currentState Name of the current state before the navigation starts.
+	 * @param newState Name of the state to be navigated to.
+	 * @param params State params object to be passed to the navigated state.
+	 * @param options Transition options object to change the behavior of the transition.
 	 */
 	public constructor(
 		public currentState: string,
@@ -52,9 +52,9 @@ export class StarkNavigateSuccess implements Action {
 
 	/**
 	 * Class constructor
-	 * @param previousState - Name of the initial state where the navigation was started.
-	 * @param currentState - Name of the state that was navigated to.
-	 * @param params - State params object that was passed to the navigated state.
+	 * @param previousState Name of the initial state where the navigation was started.
+	 * @param currentState Name of the state that was navigated to.
+	 * @param params State params object that was passed to the navigated state.
 	 */
 	public constructor(public previousState: string, public currentState: string, public params?: RawParams) {}
 }
@@ -72,10 +72,10 @@ export class StarkNavigateFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param currentState - Name of the current state before the navigation started.
-	 * @param newState - Name of the state tried to be navigated to.
-	 * @param params - State params object passed to the navigated state.
-	 * @param error - The error describing the reason of the navigation failure.
+	 * @param currentState Name of the current state before the navigation started.
+	 * @param newState Name of the state tried to be navigated to.
+	 * @param params State params object passed to the navigated state.
+	 * @param error The error describing the reason of the navigation failure.
 	 */
 	public constructor(public currentState: string, public newState: string, public params: RawParams, public error: string) {}
 }
@@ -92,10 +92,10 @@ export class StarkNavigateRejection implements Action {
 
 	/**
 	 * Class constructor
-	 * @param currentState - Name of the current state before the navigation started.
-	 * @param newState - Name of the state tried to be navigated to.
-	 * @param params - State params object passed to the navigated state.
-	 * @param reason - The reason describing why the navigation was rejected. This is normally a reason already known by the developer.
+	 * @param currentState Name of the current state before the navigation started.
+	 * @param newState Name of the state tried to be navigated to.
+	 * @param params State params object passed to the navigated state.
+	 * @param reason The reason describing why the navigation was rejected. This is normally a reason already known by the developer.
 	 */
 	public constructor(public currentState: string, public newState: string, public params: RawParams, public reason: string) {}
 }
@@ -123,7 +123,7 @@ export class StarkReload implements Action {
 
 	/**
 	 * Class constructor
-	 * @param state - Name of the state to be reloaded.
+	 * @param state Name of the state to be reloaded.
 	 */
 	public constructor(public state: string) {}
 }
@@ -141,8 +141,8 @@ export class StarkReloadSuccess implements Action {
 
 	/**
 	 * Class constructor
-	 * @param state -  name of the state that was reloaded.
-	 * @param params - State params object passed to the reloaded state.
+	 * @param state  name of the state that was reloaded.
+	 * @param params State params object passed to the reloaded state.
 	 */
 	public constructor(public state: string, public params: RawParams) {}
 }
@@ -159,8 +159,8 @@ export class StarkReloadFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param state - Name of the state tried to be reloaded.
-	 * @param params - State params object passed to the reloaded state.
+	 * @param state Name of the state tried to be reloaded.
+	 * @param params State params object passed to the reloaded state.
 	 */
 	public constructor(public state: string, public params: RawParams) {}
 }

--- a/packages/stark-core/src/modules/routing/routing.module.ts
+++ b/packages/stark-core/src/modules/routing/routing.module.ts
@@ -23,7 +23,7 @@ export class StarkRoutingModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/routing/routing.module.ts
+++ b/packages/stark-core/src/modules/routing/routing.module.ts
@@ -8,8 +8,9 @@ import { STARK_ROUTING_SERVICE, StarkRoutingServiceImpl } from "./services";
 export class StarkRoutingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
@@ -21,7 +22,7 @@ export class StarkRoutingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/routing/routing.module.ts
+++ b/packages/stark-core/src/modules/routing/routing.module.ts
@@ -9,8 +9,8 @@ export class StarkRoutingModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
 		return {
@@ -21,8 +21,8 @@ export class StarkRoutingModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/routing/services/routing-transition-hook.constants.ts
+++ b/packages/stark-core/src/modules/routing/services/routing-transition-hook.constants.ts
@@ -1,45 +1,54 @@
 /**
- * This class provides all the transition lifecycle hooks available in the router implementation. See UI-router Transition IHookRegistry
+ * This class provides all the transition lifecycle hooks available in the router implementation.
+ * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html|UI-Router Transition IHookRegistry}
  */
 export class StarkRoutingTransitionHook {
 	/**
 	 * Transition lifecycle hook invoked before a transition even begins.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onbefore
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onbefore|UI-Router onBefore hook}
 	 */
 	public static ON_BEFORE = "ON_BEFORE";
 	/**
 	 * Transition lifecycle hook invoked as a transition starts running.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onstart
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onstart|UI-Router onStart hook}
 	 */
 	public static ON_START = "ON_START";
 	/**
 	 * Transition lifecycle hook invoked (during a transition) for a specific state that was previously active will remain active (is not being entered nor exited).
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onretain
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onretain|UI-Router onRetain hook}
 	 */
 	public static ON_RETAIN = "ON_RETAIN";
 	/**
 	 * Transition lifecycle hook invoked (during a transition) when a specific state is being entered.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onenter
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onenter|UI-Router onEnter hook}
 	 */
 	public static ON_ENTER = "ON_ENTER";
 	/**
 	 * Transition lifecycle hook invoked just before a transition finishes. This hook is a last chance to cancel or redirect a transition.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onfinish
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onfinish|UI-Router onFinish hook}
 	 */
 	public static ON_FINISH = "ON_FINISH";
 	/**
 	 * Transition lifecycle hook invoked (during a transition) when a specific state is being exited.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onexit
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onexit|UI-Router onExit hook}
 	 */
 	public static ON_EXIT = "ON_EXIT";
 	/**
 	 * Transition lifecycle hook invoked after a transition successfully completes.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onsuccess
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onsuccess|UI-Router onSuccess hook}
 	 */
 	public static ON_SUCCESS = "ON_SUCCESS";
 	/**
 	 * Transition lifecycle hook invoked after a transition has been rejected for any reason.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.ihookregistry.html#onerror
+	 *
+	 * See {@link https://ui-router.github.io/ng2/docs/latest/interfaces/transition.ihookregistry.html#onerror|UI-Router onError hook}
 	 */
 	public static ON_ERROR = "ON_ERROR";
 }

--- a/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
@@ -30,9 +30,9 @@ export interface StarkRoutingService {
 	/**
 	 * Triggers the navigation to the given state
 	 *
-	 * @param newState - State name to be navigated to
-	 * @param params - (Optional) State params object to be passed to the navigated state
-	 * @param options - (Optional) Transition options object to change the behavior of the transition.
+	 * @param newState State name to be navigated to
+	 * @param params (Optional) State params object to be passed to the navigated state
+	 * @param options (Optional) Transition options object to change the behavior of the transition.
 	 * @returns Observable that will emit on navigation Success/Failure
 	 */
 	navigateTo(newState: string, params?: RawParams, options?: TransitionOptions): Observable<any>;
@@ -40,7 +40,7 @@ export interface StarkRoutingService {
 	/**
 	 * Triggers the navigation to the Home state (defined in appConfig)
 	 *
-	 * @param params - (Optional) State params object to be passed to the navigated state
+	 * @param params (Optional) State params object to be passed to the navigated state
 	 * @returns Observable that will emit on navigation Success/Failure
 	 */
 	navigateToHome(params?: RawParams): Observable<any>;
@@ -84,7 +84,7 @@ export interface StarkRoutingService {
 
 	/**
 	 * Get the config and the interpolated params of the state matching the given url path.
-	 * @param urlPath - The URL path to use in order to find a matching State configuration
+	 * @param urlPath The URL path to use in order to find a matching State configuration
 	 * @returns Object containing the state config and the interpolated params. Returns `undefined` in case there is no State matching
 	 * the given url path.
 	 */
@@ -93,7 +93,7 @@ export interface StarkRoutingService {
 	/**
 	 * Get the config of the state matching the given state name
 	 *
-	 * @param stateName - The state name to use in order to find a matching State configuration
+	 * @param stateName The state name to use in order to find a matching State configuration
 	 * @returns Config object of the state matching the given state name
 	 */
 	getStateDeclarationByStateName(stateName: string): StateDeclaration | undefined;
@@ -101,7 +101,7 @@ export interface StarkRoutingService {
 	/**
 	 * Get the params object passed at runtime to the current state (not the params object defined in the $stateProvider declaration)
 	 *
-	 * @param includeInherited - (Optional) Whether to return also parent states' inherited params. Default: `false`
+	 * @param includeInherited (Optional) Whether to return also parent states' inherited params. Default: `false`
 	 * @returns Params object (at runtime) of the current state
 	 */
 	getCurrentStateParams(includeInherited?: boolean): RawParams;
@@ -130,34 +130,34 @@ export interface StarkRoutingService {
 	/**
 	 * Checks whether the stateName passed as parameter corresponds to the current state.
 	 *
-	 * @param stateName - Name of the state to compare with the current state
-	 * @param stateParams - Optional - If provided, apart from the state name, this state params object
+	 * @param stateName Name of the state to compare with the current state
+	 * @param stateParams - Optional If provided, apart from the state name, this state params object
 	 * will be compared to the current state params in order to determine if it corresponds to the current state
 	 */
 	isCurrentUiState(stateName: string, stateParams?: RawParams): boolean;
 
 	/**
 	 * Check whether the stateName passed as parameter is included in the current state.
-	 * @param stateName -  Partial name, relative name, glob pattern, or state object to be searched for within the current state name.
-	 * @param stateParams - Param object, e.g. {sectionId: section.id}, to test against the current active state.
+	 * @param stateName  Partial name, relative name, glob pattern, or state object to be searched for within the current state name.
+	 * @param stateParams Param object, e.g. {sectionId: section.id}, to test against the current active state.
 	 */
 	isCurrentUiStateIncludedIn(stateName: string, stateParams?: RawParams): boolean;
 
 	/**
 	 * Adds a navigation rejection cause to the rejections causes known by the Routing service. These known rejection causes
 	 * will be treated differently than any other navigation error (a Rejection action will be dispatched instead of a Failure action).
-	 * @param rejectionCause - String that will be compared to the rejection reason provided by the router implementation
+	 * @param rejectionCause String that will be compared to the rejection reason provided by the router implementation
 	 */
 	addKnownNavigationRejectionCause(rejectionCause: string): void;
 
 	/**
 	 * Register a transition lifecycle {@link StarkRoutingTransitionHook|hook} that will be called by the router implementation.
-	 * @param lifecycleHook - Type of lifecycle hook to be registered.
-	 * @param matchCriteria - The [HookMatchCriteria](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookmatchcriteria.html) to determine
+	 * @param lifecycleHook Type of lifecycle hook to be registered.
+	 * @param matchCriteria The [HookMatchCriteria](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookmatchcriteria.html) to determine
 	 * which transitions the hook should be invoked for.
-	 * @param callback - A [Transition State Hook callback function](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.transitionstatehookfn.html) or
+	 * @param callback A [Transition State Hook callback function](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.transitionstatehookfn.html) or
 	 * [Transition Hook callback function](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.transitionhookfn.html)
-	 * @param options - Additional [options](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookregoptions.html) when
+	 * @param options Additional [options](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookregoptions.html) when
 	 * registering the transition hook.
 	 * @returns A function which deregisters the transition hook
 	 */
@@ -174,7 +174,7 @@ export interface StarkRoutingService {
 	 * 1. From the state's resolves if defined
 	 * 2. From the state's data if defined
 	 * 3. Otherwise, the state name is used
-	 * @param stateName - Name of the state to get the translation key from
+	 * @param stateName Name of the state to get the translation key from
 	 */
 	getTranslationKeyFromState(stateName: string): string;
 }

--- a/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
@@ -18,7 +18,7 @@ import { InjectionToken } from "@angular/core";
  */
 export const starkRoutingServiceName = "StarkRoutingService";
 /**
- * The injection Token version of the service name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkRoutingService}
  */
 export const STARK_ROUTING_SERVICE: InjectionToken<StarkRoutingService> = new InjectionToken<StarkRoutingService>(starkRoutingServiceName);
 
@@ -85,7 +85,7 @@ export interface StarkRoutingService {
 	/**
 	 * Get the config and the interpolated params of the state matching the given url path.
 	 * @param urlPath - The URL path to use in order to find a matching State configuration
-	 * @returns Object containing the state config and the interpolated params. Returns undefined in case there is no State matching
+	 * @returns Object containing the state config and the interpolated params. Returns `undefined` in case there is no State matching
 	 * the given url path.
 	 */
 	getStateConfigByUrlPath(urlPath: string): StarkStateConfigWithParams | undefined;
@@ -101,7 +101,7 @@ export interface StarkRoutingService {
 	/**
 	 * Get the params object passed at runtime to the current state (not the params object defined in the $stateProvider declaration)
 	 *
-	 * @param includeInherited - (Optional) Whether to return also parent states' inherited params. Default: false
+	 * @param includeInherited - (Optional) Whether to return also parent states' inherited params. Default: `false`
 	 * @returns Params object (at runtime) of the current state
 	 */
 	getCurrentStateParams(includeInherited?: boolean): RawParams;
@@ -151,15 +151,14 @@ export interface StarkRoutingService {
 	addKnownNavigationRejectionCause(rejectionCause: string): void;
 
 	/**
-	 * Register a transition lifecycle hook that will be called by the router implementation.
-	 * @param lifecycleHook - Type of lifecycle hook to be registered (an StarkRoutingTransitionHook value).
-	 * @param matchCriteria - To determine which transitions the hook should be invoked for.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.hookmatchcriteria.html
-	 * @param callback - Hook callback function.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.transitionstatehookfn.html
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.transitionhookfn.html
-	 * @param options - Additional options when registering the transition hook.
-	 * @link https://ui-router.github.io/ng1/docs/latest/interfaces/transition.hookregoptions.html
+	 * Register a transition lifecycle {@link StarkRoutingTransitionHook|hook} that will be called by the router implementation.
+	 * @param lifecycleHook - Type of lifecycle hook to be registered.
+	 * @param matchCriteria - The [HookMatchCriteria](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookmatchcriteria.html) to determine
+	 * which transitions the hook should be invoked for.
+	 * @param callback - A [Transition State Hook callback function](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.transitionstatehookfn.html) or
+	 * [Transition Hook callback function](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.transitionhookfn.html)
+	 * @param options - Additional [options](https://ui-router.github.io/ng2/docs/latest/interfaces/transition.hookregoptions.html) when
+	 * registering the transition hook.
 	 * @returns A function which deregisters the transition hook
 	 */
 	addTransitionHook(
@@ -170,10 +169,11 @@ export interface StarkRoutingService {
 	): () => void;
 
 	/**
-	 * Get the "translationKey" token from the state in this order:
-	 * 1.- From the state's resolves if defined
-	 * 2.- From the state's data if defined
-	 * 3.- Otherwise, the state name is used
+	 * Get the `translationKey` token from the state in this order:
+	 *
+	 * 1. From the state's resolves if defined
+	 * 2. From the state's data if defined
+	 * 3. Otherwise, the state name is used
 	 * @param stateName - Name of the state to get the translation key from
 	 */
 	getTranslationKeyFromState(stateName: string): string;

--- a/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.intf.ts
@@ -14,7 +14,7 @@ import { StarkStateConfigWithParams } from "./state-config-with-params.intf";
 import { InjectionToken } from "@angular/core";
 
 /**
- * The name of the Stark Routing Service, in case injection is needed
+ * The name of the service, in case injection is needed
  */
 export const starkRoutingServiceName = "StarkRoutingService";
 /**
@@ -144,7 +144,7 @@ export interface StarkRoutingService {
 	isCurrentUiStateIncludedIn(stateName: string, stateParams?: RawParams): boolean;
 
 	/**
-	 * Adds a navigation rejection cause to the rejections causes known by the routing service. These known rejection causes
+	 * Adds a navigation rejection cause to the rejections causes known by the Routing service. These known rejection causes
 	 * will be treated differently than any other navigation error (a Rejection action will be dispatched instead of a Failure action).
 	 * @param rejectionCause - String that will be compared to the rejection reason provided by the router implementation
 	 */

--- a/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
@@ -3,7 +3,7 @@ import { Component, Injector, NgModuleFactoryLoader, NO_ERRORS_SCHEMA, SystemJsN
 import { fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
 import { Ng2StateDeclaration, UIRouterModule, TransitionPromise } from "@uirouter/angular";
 import { RawParams, StateDeclaration, StateObject, StateService, TransitionService, UIRouter } from "@uirouter/core";
-// FIXME Adapt switchMap code --> See: https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md#howto-result-selector-migration
+// FIXME Adapt switchMap code --> See: https://github.com/ReactiveX/rxjs/blob/6.x/docs_app/content/guide/v6/migration.md#howto-result-selector-migration
 import { catchError, switchMap, tap } from "rxjs/operators";
 import { throwError } from "rxjs";
 import { Store } from "@ngrx/store";

--- a/packages/stark-core/src/modules/routing/services/routing.service.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.ts
@@ -52,6 +52,9 @@ interface StarkState {
 	params?: RawParams;
 }
 
+/**
+ * @ignore
+ */
 @Injectable()
 export class StarkRoutingServiceImpl implements StarkRoutingService {
 	public lastTransition?: Transition;
@@ -243,28 +246,28 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 	): () => void {
 		switch (lifecycleHook) {
 			case StarkRoutingTransitionHook.ON_BEFORE:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onbefore
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onbefore
 				return <() => void>this.$transitions.onBefore(matchCriteria, <TransitionHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_START:
-				// see https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onstart
+				// see https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onstart
 				return <() => void>this.$transitions.onStart(matchCriteria, <TransitionHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_EXIT:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onexit
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onexit
 				return <() => void>this.$transitions.onExit(matchCriteria, <TransitionStateHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_RETAIN:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onretain
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onretain
 				return <() => void>this.$transitions.onRetain(matchCriteria, <TransitionStateHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_ENTER:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onenter
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onenter
 				return <() => void>this.$transitions.onEnter(matchCriteria, <TransitionStateHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_FINISH:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onfinish
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onfinish
 				return <() => void>this.$transitions.onFinish(matchCriteria, <TransitionHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_SUCCESS:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onsuccess
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onsuccess
 				return <() => void>this.$transitions.onSuccess(matchCriteria, <TransitionHookFn>callback, options);
 			case StarkRoutingTransitionHook.ON_ERROR:
-				// see: https://ui-router.github.io/ng1/docs/latest/classes/transition.transitionservice.html#onerror
+				// see: https://ui-router.github.io/ng2/docs/latest/classes/transition.transitionservice.html#onerror
 				return <() => void>this.$transitions.onError(matchCriteria, <TransitionHookFn>callback, options);
 			default:
 				throw new Error(starkRoutingServiceName + ": lifecycle hook unknown => " + lifecycleHook);
@@ -333,7 +336,7 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 							// dispatch corresponding action to allow the user to trigger his own effects if needed
 							this.store.dispatch(failureAction);
 
-							// reference: https://ui-router.github.io/docs/latest/classes/state.stateservice.html#go
+							// reference: https://ui-router.github.io/ng2/docs/latest/classes/state.stateservice.html#go
 							if (rejectionString.match(/transition superseded|transition prevented|transition aborted|transition failed/)) {
 								this.logger.warn(starkRoutingServiceName + ": " + rejectionString);
 							} else if (rejectionString.match(/resolve error/)) {
@@ -349,7 +352,7 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 					}
 				}
 
-				// HookResult: https://ui-router.github.io/docs/latest/modules/transition.html#hookresult
+				// HookResult: https://ui-router.github.io/ng2/docs/latest/modules/transition.html#hookresult
 				// boolean | TargetState | void | Promise<boolean | TargetState | void>
 				return false;
 			},
@@ -357,7 +360,7 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 		);
 
 		// declare the onInvalid handler
-		// https://ui-router.github.io/ng1/docs/latest/classes/state.stateservice.html#oninvalid
+		// https://ui-router.github.io/ng2/docs/latest/classes/state.stateservice.html#oninvalid
 		this.$state.onInvalid(
 			(toState?: TargetState, fromState?: TargetState): HookResult => {
 				const errorType = "Invalid state change";
@@ -382,14 +385,14 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 				// TODO redirect to the generic error page once implemented: https://jira.prd.nbb/browse/NG-847
 				// should probably be done via an effect reacting to the StarkRoutingActions.navigateFailure action
 
-				// HookResult: https://ui-router.github.io/docs/latest/modules/transition.html#hookresult
+				// HookResult: https://ui-router.github.io/ng2/docs/latest/modules/transition.html#hookresult
 				// boolean | TargetState | void | Promise<boolean | TargetState | void>
 				return false;
 			}
 		);
 
 		// provide custom default error handler
-		// https://ui-router.github.io/ng1/docs/latest/classes/state.stateservice.html#defaulterrorhandler
+		// https://ui-router.github.io/ng2/docs/latest/classes/state.stateservice.html#defaulterrorhandler
 		this.$state.defaultErrorHandler((error: any): void => {
 			let stringError: string;
 			if (error instanceof Rejection) {
@@ -421,7 +424,7 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 			hookMatchCriteria,
 			(transition: Transition): HookResult => {
 				this.lastTransition = transition;
-				// HookResult: https://ui-router.github.io/docs/latest/modules/transition.html#hookresult
+				// HookResult: https://ui-router.github.io/ng2/docs/latest/modules/transition.html#hookresult
 				// boolean | TargetState | void | Promise<boolean | TargetState | void>
 
 				const previousStateName: string = <string>transition.from().name;

--- a/packages/stark-core/src/modules/routing/services/routing.service.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.ts
@@ -552,8 +552,8 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 
 	/**
 	 * Check whether the given state is a parent/ancestor of the given currentState
-	 * @param state - The state that will be checked whether is a parent of the currentState
-	 * @param currentState - (Optional) If not provided, it is set to the current router state
+	 * @param state The state that will be checked whether is a parent of the currentState
+	 * @param currentState (Optional) If not provided, it is set to the current router state
 	 */
 	private isParentState(state: StateObject, currentState: StateObject = this.getCurrentState()): boolean {
 		if (currentState.parent) {

--- a/packages/stark-core/src/modules/session/actions/session.actions.ts
+++ b/packages/stark-core/src/modules/session/actions/session.actions.ts
@@ -32,7 +32,7 @@ export class StarkChangeLanguage implements Action {
 
 	/**
 	 * Class constructor
-	 * @param languageId - The target language to change to.
+	 * @param languageId The target language to change to.
 	 */
 	public constructor(public languageId: string) {}
 }
@@ -49,7 +49,7 @@ export class StarkChangeLanguageSuccess implements Action {
 
 	/**
 	 * Class constructor
-	 * @param languageId -  The target language that was successfully changed to.
+	 * @param languageId  The target language that was successfully changed to.
 	 */
 	public constructor(public languageId: string) {}
 }
@@ -65,7 +65,7 @@ export class StarkChangeLanguageFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param error - The error that caused the language change to fail.
+	 * @param error The error that caused the language change to fail.
 	 */
 	public constructor(public error: any) {}
 }
@@ -82,7 +82,7 @@ export class StarkInitializeSession implements Action {
 
 	/**
 	 * Class constructor
-	 * @param user - The user whose session will be initialized.
+	 * @param user The user whose session will be initialized.
 	 */
 	public constructor(public user: StarkUser) {}
 }
@@ -140,7 +140,7 @@ export class StarkSessionTimeoutCountdownStart implements Action {
 
 	/**
 	 * Class constructor
-	 * @param countdown - The countdown until the session will be automatically destroyed.
+	 * @param countdown The countdown until the session will be automatically destroyed.
 	 */
 	public constructor(public countdown: number) {}
 }

--- a/packages/stark-core/src/modules/session/actions/session.actions.ts
+++ b/packages/stark-core/src/modules/session/actions/session.actions.ts
@@ -26,7 +26,6 @@ export enum StarkSessionActionTypes {
 export class StarkChangeLanguage implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.CHANGE_LANGUAGE = StarkSessionActionTypes.CHANGE_LANGUAGE;
 
@@ -43,7 +42,6 @@ export class StarkChangeLanguage implements Action {
 export class StarkChangeLanguageSuccess implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.CHANGE_LANGUAGE_SUCCESS = StarkSessionActionTypes.CHANGE_LANGUAGE_SUCCESS;
 
@@ -60,7 +58,6 @@ export class StarkChangeLanguageSuccess implements Action {
 export class StarkChangeLanguageFailure implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.CHANGE_LANGUAGE_FAILURE = StarkSessionActionTypes.CHANGE_LANGUAGE_FAILURE;
 
@@ -77,7 +74,6 @@ export class StarkChangeLanguageFailure implements Action {
 export class StarkInitializeSession implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.INITIALIZE_SESSION = StarkSessionActionTypes.INITIALIZE_SESSION;
 
@@ -94,7 +90,6 @@ export class StarkInitializeSession implements Action {
 export class StarkInitializeSessionSuccess implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.INITIALIZE_SESSION_SUCCESS = StarkSessionActionTypes.INITIALIZE_SESSION_SUCCESS;
 }
@@ -110,7 +105,6 @@ export class StarkInitializeSessionSuccess implements Action {
 export class StarkDestroySession implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.DESTROY_SESSION = StarkSessionActionTypes.DESTROY_SESSION;
 }
@@ -122,7 +116,6 @@ export class StarkDestroySession implements Action {
 export class StarkDestroySessionSuccess implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.DESTROY_SESSION_SUCCESS = StarkSessionActionTypes.DESTROY_SESSION_SUCCESS;
 }
@@ -134,7 +127,6 @@ export class StarkDestroySessionSuccess implements Action {
 export class StarkSessionTimeoutCountdownStart implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_START = StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_START;
 
@@ -152,7 +144,6 @@ export class StarkSessionTimeoutCountdownStart implements Action {
 export class StarkSessionTimeoutCountdownStop implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_STOP = StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_STOP;
 }
@@ -163,7 +154,6 @@ export class StarkSessionTimeoutCountdownStop implements Action {
 export class StarkSessionTimeoutCountdownFinish implements Action {
 	/**
 	 * Defines the type of NGRX action to perform.
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_FINISH =
 		StarkSessionActionTypes.SESSION_TIMEOUT_COUNTDOWN_FINISH;
@@ -177,7 +167,6 @@ export class StarkSessionTimeoutCountdownFinish implements Action {
 export class StarkSessionLogout implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.SESSION_LOGOUT = StarkSessionActionTypes.SESSION_LOGOUT;
 }
@@ -188,7 +177,6 @@ export class StarkSessionLogout implements Action {
 export class StarkUserActivityTrackingPause implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.USER_ACTIVITY_TRACKING_PAUSE = StarkSessionActionTypes.USER_ACTIVITY_TRACKING_PAUSE;
 }
@@ -199,7 +187,6 @@ export class StarkUserActivityTrackingPause implements Action {
 export class StarkUserActivityTrackingResume implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSessionActionTypes
 	 */
 	public readonly type: StarkSessionActionTypes.USER_ACTIVITY_TRACKING_RESUME = StarkSessionActionTypes.USER_ACTIVITY_TRACKING_RESUME;
 }

--- a/packages/stark-core/src/modules/session/actions/session.actions.ts
+++ b/packages/stark-core/src/modules/session/actions/session.actions.ts
@@ -2,7 +2,7 @@ import { Action } from "@ngrx/store";
 import { StarkUser } from "../../user/entities";
 
 /**
- * Actions related to stark session service
+ * Actions related to {@link StarkSessionService}
  */
 export enum StarkSessionActionTypes {
 	CHANGE_LANGUAGE = "[StarkSession] Change Language",
@@ -21,7 +21,8 @@ export enum StarkSessionActionTypes {
 }
 
 /**
- * Triggered when the setCurrentLanguage() method is called, just before changing the current session's language.
+ * Triggered when the [StarkSessionService setCurrentLanguage()]{@link StarkSessionService#setCurrentLanguage} method is called,
+ * just before changing the current session's language.
  */
 export class StarkChangeLanguage implements Action {
 	/**
@@ -37,7 +38,8 @@ export class StarkChangeLanguage implements Action {
 }
 
 /**
- * Triggered when the current session's language has been successfully changed by calling the setCurrentLanguage() method.
+ * Triggered when the current session's language has been successfully changed by calling
+ * the [StarkSessionService setCurrentLanguage()]{@link StarkSessionService#setCurrentLanguage} method.
  */
 export class StarkChangeLanguageSuccess implements Action {
 	/**
@@ -69,7 +71,8 @@ export class StarkChangeLanguageFailure implements Action {
 }
 
 /**
- * Triggered by the login() method before the process to initialize the session for the given user starts.
+ * Triggered by the [StarkSessionService login()]{@link StarkSessionService#login} method before the process to
+ * initialize the session for the given user starts.
  */
 export class StarkInitializeSession implements Action {
 	/**
@@ -96,11 +99,13 @@ export class StarkInitializeSessionSuccess implements Action {
 
 /**
  * Triggered before the process to destroy the user's session starts right after the HTTP logout call has been sent.
+ *
  * This action is dispatched whenever the user is going to be logged out due to:
- * 1) Manually clicking in the App Logout component
- * 2) Calling the logout() method.
- * 3) Closing the browser tab.
- * 4) Being inactive for a certain period of time reaching the idle timeout defined by the application.
+ * 1. Manually clicking in the App Logout component (provided by the `StarkUI` package)
+ * 2. Calling the [StarkSessionService logout()]{@link StarkSessionService#logout} method.
+ * 3. Closing the browser tab.
+ * 4. Being inactive for a certain period of time reaching the idle timeout defined by the
+ * application's [StarkApplicationConfig sessionTimeout]{@link StarkApplicationConfig#sessionTimeout}.
  */
 export class StarkDestroySession implements Action {
 	/**
@@ -122,7 +127,10 @@ export class StarkDestroySessionSuccess implements Action {
 
 /**
  * Triggered when the countdown to automatically destroy the user's session due to inactivity starts.
- * The countdown is defined in the sessionTimeoutWarningPeriod option in the application configuration. By default is set to 15 seconds.
+ *
+ * The countdown is defined in the application's [StarkApplicationConfig sessionTimeoutWarningPeriod]{@link StarkApplicationConfig#sessionTimeoutWarningPeriod}.
+ *
+ * By default is set to 15 seconds.
  */
 export class StarkSessionTimeoutCountdownStart implements Action {
 	/**
@@ -139,6 +147,7 @@ export class StarkSessionTimeoutCountdownStart implements Action {
 
 /**
  * Triggered when the countdown to automatically destroy the user's session due to inactivity stops.
+ * 
  * This countdown stops automatically when the user is active again and no longer idle.
  */
 export class StarkSessionTimeoutCountdownStop implements Action {
@@ -160,9 +169,11 @@ export class StarkSessionTimeoutCountdownFinish implements Action {
 }
 
 /**
- * Triggered when the user is about to be logged out and the HTTP logout call to be sent. This action is called before the process to destroy the user's session starts.
- * This action is dispatched by the logout() method or in case the browser tab was closed.
- * This action is dispatched before the StarkSessionActions.DESTROY_SESSION action.
+ * Triggered when the user is about to be logged out and the HTTP logout call to be sent.
+ * This action is called before the process to destroy the user's session starts.
+ *
+ * This action is dispatched by the [StarkSessionService logout()]{@link StarkSessionService#logout} method or in case the browser tab was closed and is dispatched before
+ * the {@link StarkDestroySession} action.
  */
 export class StarkSessionLogout implements Action {
 	/**
@@ -172,7 +183,8 @@ export class StarkSessionLogout implements Action {
 }
 
 /**
- * Triggered by the pauseUserActivityTracking() method when the user activity tracking (automatically done by the Session service) is paused.
+ * Triggered by the [StarkSessionService pauseUserActivityTracking()]{@link StarkSessionService#pauseUserActivityTracking} method
+ * when the user activity tracking is paused (automatically done by the {@link StarkSessionService}).
  */
 export class StarkUserActivityTrackingPause implements Action {
 	/**
@@ -182,7 +194,8 @@ export class StarkUserActivityTrackingPause implements Action {
 }
 
 /**
- * Triggered by the resumeUserActivityTracking()  method when the user activity tracking (automatically done by the Session service) is resumed.
+ * Triggered by the [StarkSessionService resumeUserActivityTracking()]{@link StarkSessionService#resumeUserActivityTracking}  method
+ * when the user activity tracking is resumed (automatically done by the {@link StarkSessionService}).
  */
 export class StarkUserActivityTrackingResume implements Action {
 	/**

--- a/packages/stark-core/src/modules/session/components/app-container.component.ts
+++ b/packages/stark-core/src/modules/session/components/app-container.component.ts
@@ -24,8 +24,8 @@ const componentName = "stark-app-container";
 export class StarkAppContainerComponent implements OnInit {
 	/**
 	 * Class constructor
-	 * @param logger - The logger of the application
-	 * @param routingService - The routing service of the application
+	 * @param logger - The `StarkLoggingService` instance of the application.
+	 * @param routingService - The `StarkRoutingService` instance of the application.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService,

--- a/packages/stark-core/src/modules/session/components/app-container.component.ts
+++ b/packages/stark-core/src/modules/session/components/app-container.component.ts
@@ -24,8 +24,8 @@ const componentName = "stark-app-container";
 export class StarkAppContainerComponent implements OnInit {
 	/**
 	 * Class constructor
-	 * @param logger - The `StarkLoggingService` instance of the application.
-	 * @param routingService - The `StarkRoutingService` instance of the application.
+	 * @param logger The `StarkLoggingService` instance of the application.
+	 * @param routingService The `StarkRoutingService` instance of the application.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService,

--- a/packages/stark-core/src/modules/session/entities/session-config.entity.intf.ts
+++ b/packages/stark-core/src/modules/session/entities/session-config.entity.intf.ts
@@ -6,11 +6,11 @@ import { InjectionToken } from "@angular/core";
 export const STARK_SESSION_CONFIG: InjectionToken<StarkSessionConfig> = new InjectionToken<StarkSessionConfig>("StarkSessionConfig");
 
 /**
- * Definition of the configuration object for the Stark Session service
+ * Definition of the configuration object for the {@link StarkSessionService}
  */
 export interface StarkSessionConfig {
 	/**
-	 * Router state for the Login page where the user can choose a profile and use it to impersonate himself as someone else.
+	 * Router state for the {@link starkLoginStateName} where the user can choose a profile and use it to impersonate himself as someone else.
 	 * This state is only used in DEVELOPMENT.
 	 */
 	loginStateName?: string;

--- a/packages/stark-core/src/modules/session/entities/session-config.entity.intf.ts
+++ b/packages/stark-core/src/modules/session/entities/session-config.entity.intf.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from "@angular/core";
 
 /**
- * The InjectionToken version of the config name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkSessionConfig}
  */
 export const STARK_SESSION_CONFIG: InjectionToken<StarkSessionConfig> = new InjectionToken<StarkSessionConfig>("StarkSessionConfig");
 

--- a/packages/stark-core/src/modules/session/entities/session.entity.intf.ts
+++ b/packages/stark-core/src/modules/session/entities/session.entity.intf.ts
@@ -1,7 +1,7 @@
 import { StarkUser } from "../../user/entities";
 
 /**
- * The StarkSession interface describes the information that is stored and available during the whole session of a user.
+ * Interface that describes the information that is stored and available during the whole session of a user.
  */
 export interface StarkSession {
 	/**

--- a/packages/stark-core/src/modules/session/entities/session.entity.intf.ts
+++ b/packages/stark-core/src/modules/session/entities/session.entity.intf.ts
@@ -10,8 +10,7 @@ export interface StarkSession {
 	currentLanguage: string;
 
 	/**
-	 * The current user logged in the application (if there is one logged in), otherwise it will be undefined
-	 * @link StarkUser
+	 * The current {@link StarkUser} logged in the application (if there is one logged in), otherwise it will be `undefined`
 	 */
 	user?: StarkUser;
 }

--- a/packages/stark-core/src/modules/session/reducers/index.ts
+++ b/packages/stark-core/src/modules/session/reducers/index.ts
@@ -4,37 +4,29 @@ import { StarkSessionActions } from "../actions";
 import { sessionReducer } from "./session.reducer";
 
 /**
- * We define part of the state assigned to the session module
+ * Defines the part of the state assigned to the {@link StarkSessionModule}
  */
 export interface StarkSessionState {
 	/**
-	 * The session property
-	 * @link StarkSession
+	 * State corresponding to the {@link StarkSessionModule}
 	 */
 	session: StarkSession;
 }
 
 /**
- * We assign a reducer to our session property
+ * Reducers assigned to the each property of the {@link StarkSessionModule}'s state
  */
 export const starkSessionReducers: ActionReducerMap<StarkSessionState, StarkSessionActions> = {
 	/**
-	 * the reducer is assigned to our property
+	 * Reducer assigned to the state's `session` property
 	 */
 	session: sessionReducer
 };
 
 /**
- * This will create the session feature used by the selector to find the session module in the state
- */
-export const selectStarkSessionFeature: MemoizedSelector<object, StarkSessionState> = createFeatureSelector<StarkSessionState>(
-	"StarkSession"
-);
-
-/**
- * The selector will return the part of the state assigned to the logging when called
+ * NGRX Selector for the {@link StarkSessionModule}'s state
  */
 export const selectStarkSession: MemoizedSelector<object, StarkSession> = createSelector(
-	selectStarkSessionFeature,
+	createFeatureSelector<StarkSessionState>("StarkSession"),
 	(state: StarkSessionState) => state.session
 );

--- a/packages/stark-core/src/modules/session/reducers/session.reducer.ts
+++ b/packages/stark-core/src/modules/session/reducers/session.reducer.ts
@@ -9,16 +9,16 @@ export const starkSessionStoreKey = "starkSession";
 /**
  *  Defines the initial state of the reducer
  */
-const INITIAL_STATE: StarkSession = new StarkSessionImpl();
+const INITIAL_SESSION_STATE: StarkSession = new StarkSessionImpl();
 
 /**
- * Definition of the session reducer
+ * Definition of the `session` reducer
  * @param state: the state of the reducer
  * @param action: the action to apply to the reducer
  * @returns The new `StarkSession` state
  */
 export function sessionReducer(
-	state: Readonly<StarkSession> = INITIAL_STATE,
+	state: Readonly<StarkSession> = INITIAL_SESSION_STATE,
 	action: Readonly<StarkSessionActions>
 ): Readonly<StarkSession> {
 	// the new state will be calculated from the data coming in the actions

--- a/packages/stark-core/src/modules/session/reducers/session.reducer.ts
+++ b/packages/stark-core/src/modules/session/reducers/session.reducer.ts
@@ -15,7 +15,7 @@ const INITIAL_STATE: StarkSession = new StarkSessionImpl();
  * Definition of the session reducer
  * @param state: the state of the reducer
  * @param action: the action to apply to the reducer
- * @returns a starkSession instance
+ * @returns The new `StarkSession` state
  */
 export function sessionReducer(
 	state: Readonly<StarkSession> = INITIAL_STATE,

--- a/packages/stark-core/src/modules/session/routes.ts
+++ b/packages/stark-core/src/modules/session/routes.ts
@@ -17,7 +17,7 @@ export function resolveTargetRoute(
 	/**
 	 * Get the corresponding registered state that matches with the given URL.
 	 * If the state is part of a lazy loaded module, then such module is loaded first and then the URL is searched again to get the correct state
-	 * @param targetUrl - the URL of the target state being searched
+	 * @param targetUrl - The URL of the target state being searched
 	 */
 	function getTargetStateByUrl(targetUrl: string): StarkStateConfigWithParams | undefined {
 		let targetState: StarkStateConfigWithParams | undefined = routingService.getStateConfigByUrlPath(targetUrl);
@@ -61,23 +61,23 @@ export function resolveTargetRoute(
 }
 
 /**
- * Check if targetRoute is defined and returns the name of the state OR undefined.
- * @param targetRoute - returned value of resolveTargetRoute method
+ * Check if targetRoute is defined and returns the name of the state OR `undefined`.
+ * @param targetRoute - Returned value of `resolveTargetRoute` method
  */
 export function resolveTargetState(targetRoute?: StarkStateConfigWithParams): Promise<string | undefined> {
 	return of(typeof targetRoute !== "undefined" ? targetRoute.state.name : undefined).toPromise();
 }
 
 /**
- * Check if targetRoute is defined and returns the params of the state OR undefined.
- * @param targetRoute - returned value of resolveTargetRoute method
+ * Check if targetRoute is defined and returns the params of the state OR `undefined`.
+ * @param targetRoute - Returned value of `resolveTargetRoute` method
  */
 export function resolveTargetStateParams(targetRoute?: StarkStateConfigWithParams): Promise<RawParams | undefined> {
 	return of(typeof targetRoute !== "undefined" ? targetRoute.paramValues : undefined).toPromise();
 }
 
 /**
- * States defined by Session Module
+ * States defined by {@link StarkSessionModule}
  */
 export const SESSION_STATES: Ng2StateDeclaration[] = [
 	{

--- a/packages/stark-core/src/modules/session/routes.ts
+++ b/packages/stark-core/src/modules/session/routes.ts
@@ -17,7 +17,7 @@ export function resolveTargetRoute(
 	/**
 	 * Get the corresponding registered state that matches with the given URL.
 	 * If the state is part of a lazy loaded module, then such module is loaded first and then the URL is searched again to get the correct state
-	 * @param targetUrl - The URL of the target state being searched
+	 * @param targetUrl The URL of the target state being searched
 	 */
 	function getTargetStateByUrl(targetUrl: string): StarkStateConfigWithParams | undefined {
 		let targetState: StarkStateConfigWithParams | undefined = routingService.getStateConfigByUrlPath(targetUrl);
@@ -62,7 +62,7 @@ export function resolveTargetRoute(
 
 /**
  * Check if targetRoute is defined and returns the name of the state OR `undefined`.
- * @param targetRoute - Returned value of `resolveTargetRoute` method
+ * @param targetRoute Returned value of `resolveTargetRoute` method
  */
 export function resolveTargetState(targetRoute?: StarkStateConfigWithParams): Promise<string | undefined> {
 	return of(typeof targetRoute !== "undefined" ? targetRoute.state.name : undefined).toPromise();
@@ -70,7 +70,7 @@ export function resolveTargetState(targetRoute?: StarkStateConfigWithParams): Pr
 
 /**
  * Check if targetRoute is defined and returns the params of the state OR `undefined`.
- * @param targetRoute - Returned value of `resolveTargetRoute` method
+ * @param targetRoute Returned value of `resolveTargetRoute` method
  */
 export function resolveTargetStateParams(targetRoute?: StarkStateConfigWithParams): Promise<RawParams | undefined> {
 	return of(typeof targetRoute !== "undefined" ? targetRoute.paramValues : undefined).toPromise();

--- a/packages/stark-core/src/modules/session/services/session.service.intf.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.intf.ts
@@ -7,7 +7,7 @@ import { StarkUser } from "../../user/entities";
  */
 export const starkSessionServiceName = "StarkSessionService";
 /**
- * Injection Token version of the Service Name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkSessionService}
  */
 export const STARK_SESSION_SERVICE: InjectionToken<StarkSessionService> = new InjectionToken<StarkSessionService>(starkSessionServiceName);
 
@@ -23,9 +23,8 @@ export interface StarkSessionService {
 	readonly devAuthenticationHeaders: Map<string, string | string[]>;
 
 	/**
-	 * Returns the session's current user
+	 * Returns the session's current {@link StarkUser}
 	 *
-	 * @link StarkUser
 	 * @returns Observable that will emit the current user and the latest value whenever it changes
 	 */
 	getCurrentUser(): Observable<StarkUser | undefined>;
@@ -46,9 +45,8 @@ export interface StarkSessionService {
 	setCurrentLanguage(newLanguage: string): void;
 
 	/**
-	 * Performs the login of the user. Internally, it performs all the necessary actions to initialize the session.
+	 * Performs the login of the given {@link StarkUser}. Internally, it performs all the necessary actions to initialize the session.
 	 *
-	 * @link StarkUser
 	 * @param user - The user to log in.
 	 */
 	login(user: StarkUser): void;

--- a/packages/stark-core/src/modules/session/services/session.service.intf.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.intf.ts
@@ -3,7 +3,7 @@ import { Observable } from "rxjs";
 import { StarkUser } from "../../user/entities";
 
 /**
- * Name of the Session Service, in case injection is required
+ * The name of the service, in case injection is needed
  */
 export const starkSessionServiceName = "StarkSessionService";
 /**

--- a/packages/stark-core/src/modules/session/services/session.service.intf.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.intf.ts
@@ -40,14 +40,14 @@ export interface StarkSessionService {
 	 * Sets the current session's language (language Id).
 	 * It dispatches a CHANGE_LANGUAGE action to the NGRX-Store
 	 *
-	 * @param newLanguage - The language Id to be set
+	 * @param newLanguage The language Id to be set
 	 */
 	setCurrentLanguage(newLanguage: string): void;
 
 	/**
 	 * Performs the login of the given {@link StarkUser}. Internally, it performs all the necessary actions to initialize the session.
 	 *
-	 * @param user - The user to log in.
+	 * @param user The user to log in.
 	 */
 	login(user: StarkUser): void;
 

--- a/packages/stark-core/src/modules/session/services/session.service.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.ts
@@ -44,6 +44,9 @@ import { starkAppExitStateName, starkAppInitStateName, starkSessionExpiredStateN
  */
 export const starkUnauthenticatedUserError = "StarkSessionService => user not authenticated";
 
+/**
+ * @ignore
+ */
 @Injectable()
 export class StarkSessionServiceImpl implements StarkSessionService {
 	public keepalive?: Keepalive;

--- a/packages/stark-core/src/modules/session/services/session.service.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.ts
@@ -106,7 +106,7 @@ export class StarkSessionServiceImpl implements StarkSessionService {
 
 	/**
 	 * Validates the StarkSessionConfig provided.
-	 * @param customConfig - Custom configuration object passed via the StarkSessionModule.forRoot() method
+	 * @param customConfig Custom configuration object passed via the StarkSessionModule.forRoot() method
 	 * @throws In case the configuration object passed via the StarkSessionModule.forRoot() method is not valid
 	 */
 	protected validateSessionConfig(customConfig: StarkSessionConfig): void {
@@ -185,7 +185,7 @@ export class StarkSessionServiceImpl implements StarkSessionService {
 	/**
 	 * Performs all the necessary actions to initialize the session.
 	 * It dispatches a INITIALIZE_SESSION action to the NGRX-Store
-	 * @param user - The user used to initialize the session.
+	 * @param user The user used to initialize the session.
 	 */
 	protected initializeSession(user: StarkUser): void {
 		this.store.dispatch(new StarkInitializeSession(user));

--- a/packages/stark-core/src/modules/session/session.module.ts
+++ b/packages/stark-core/src/modules/session/session.module.ts
@@ -29,8 +29,9 @@ import { StarkAppContainerComponent } from "./components";
 export class StarkSessionModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @param sessionConfig - Object containing the configuration (if any) for the `StarkSessionService`
 	 * @returns A module with providers
 	 */
@@ -47,7 +48,7 @@ export class StarkSessionModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 * @param routingService - The `StarkRoutingService` instance of the application.
 	 * @param sessionConfig - The configuration of the `StarkSessionModule`

--- a/packages/stark-core/src/modules/session/session.module.ts
+++ b/packages/stark-core/src/modules/session/session.module.ts
@@ -30,9 +30,9 @@ export class StarkSessionModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @param sessionConfig - Object containing the configuration (if any) for the Session service
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @param sessionConfig - Object containing the configuration (if any) for the `StarkSessionService`
+	 * @returns A module with providers
 	 */
 	public static forRoot(sessionConfig?: StarkSessionConfig): ModuleWithProviders {
 		return {
@@ -47,11 +47,11 @@ export class StarkSessionModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
-	 * @param routingService - The routing service of the application
-	 * @param sessionConfig - The configuration of the session module
-	 * @param appInitStatus - A class that reflects the state of running {@link APP_INITIALIZER}s
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
+	 * @param routingService - The `StarkRoutingService` instance of the application.
+	 * @param sessionConfig - The configuration of the `StarkSessionModule`
+	 * @param appInitStatus - A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/session/session.module.ts
+++ b/packages/stark-core/src/modules/session/session.module.ts
@@ -32,7 +32,7 @@ export class StarkSessionModule {
 	 * so the `forRoot()` should be called only by the `AppModule`.
 	 *
 	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
-	 * @param sessionConfig - Object containing the configuration (if any) for the `StarkSessionService`
+	 * @param sessionConfig Object containing the configuration (if any) for the `StarkSessionService`
 	 * @returns A module with providers
 	 */
 	public static forRoot(sessionConfig?: StarkSessionConfig): ModuleWithProviders {
@@ -49,10 +49,10 @@ export class StarkSessionModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
-	 * @param routingService - The `StarkRoutingService` instance of the application.
-	 * @param sessionConfig - The configuration of the `StarkSessionModule`
-	 * @param appInitStatus - A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
+	 * @param parentModule The parent module
+	 * @param routingService The `StarkRoutingService` instance of the application.
+	 * @param sessionConfig The configuration of the `StarkSessionModule`
+	 * @param appInitStatus A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/settings/actions/settings.actions.ts
+++ b/packages/stark-core/src/modules/settings/actions/settings.actions.ts
@@ -17,13 +17,12 @@ export enum StarkSettingsActionTypes {
 export class StarkPersistPreferredLanguage implements Action {
 	/**
 	 * The type of action
-	 * @link StarkSettingsActionTypes
 	 */
 	public readonly type: StarkSettingsActionTypes.PERSIST_PREFERRED_LANGUAGE = StarkSettingsActionTypes.PERSIST_PREFERRED_LANGUAGE;
 
 	/**
 	 * Class constructor
-	 * @param language - the language to persist
+	 * @param language - The language to persist
 	 */
 	public constructor(public language: string) {}
 }
@@ -53,7 +52,7 @@ export class StarkPersistPreferredLanguageFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param error - the reason why the preferred language could not be persisted
+	 * @param error - The reason why the preferred language could not be persisted
 	 */
 	public constructor(public error: any) {}
 }
@@ -70,7 +69,7 @@ export class StarkSetPreferredLanguage implements Action {
 
 	/**
 	 * Class constructor
-	 * @param language - the new preferred language
+	 * @param language - The new preferred language
 	 */
 	public constructor(public language: string) {}
 }

--- a/packages/stark-core/src/modules/settings/actions/settings.actions.ts
+++ b/packages/stark-core/src/modules/settings/actions/settings.actions.ts
@@ -22,7 +22,7 @@ export class StarkPersistPreferredLanguage implements Action {
 
 	/**
 	 * Class constructor
-	 * @param language - The language to persist
+	 * @param language The language to persist
 	 */
 	public constructor(public language: string) {}
 }
@@ -52,7 +52,7 @@ export class StarkPersistPreferredLanguageFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param error - The reason why the preferred language could not be persisted
+	 * @param error The reason why the preferred language could not be persisted
 	 */
 	public constructor(public error: any) {}
 }
@@ -69,7 +69,7 @@ export class StarkSetPreferredLanguage implements Action {
 
 	/**
 	 * Class constructor
-	 * @param language - The new preferred language
+	 * @param language The new preferred language
 	 */
 	public constructor(public language: string) {}
 }

--- a/packages/stark-core/src/modules/settings/effects/settings.effects.ts
+++ b/packages/stark-core/src/modules/settings/effects/settings.effects.ts
@@ -12,23 +12,15 @@ import { STARK_SESSION_SERVICE, StarkSessionService } from "../../session/servic
 @Injectable()
 export class StarkSettingsEffects {
 	/**
-	 * The session service
-	 * @link StarkSessionService
-	 */
-	public sessionService: StarkSessionService;
-
-	/**
 	 * Class constructor
-	 * @param actions$ - the action to perform
-	 * @param sessionService - the session Service
+	 * @param actions$ - The action to perform
+	 * @param sessionService - The `StarkSessionService` instance of the application
 	 */
-	public constructor(private actions$: Actions, @Inject(STARK_SESSION_SERVICE) sessionService: StarkSessionService) {
-		this.sessionService = sessionService;
-	}
+	public constructor(private actions$: Actions, @Inject(STARK_SESSION_SERVICE) public sessionService: StarkSessionService) {}
 
 	/**
 	 * The Set preferred language action will be used to change the language of the current session
-	 * dispatch: false => because this effect does not dispatch an action
+	 * `dispatch: false` => because this effect does not dispatch an action
 	 */
 	@Effect({ dispatch: false })
 	public setPreferredLanguage$(): Observable<void> {

--- a/packages/stark-core/src/modules/settings/effects/settings.effects.ts
+++ b/packages/stark-core/src/modules/settings/effects/settings.effects.ts
@@ -13,8 +13,8 @@ import { STARK_SESSION_SERVICE, StarkSessionService } from "../../session/servic
 export class StarkSettingsEffects {
 	/**
 	 * Class constructor
-	 * @param actions$ - The action to perform
-	 * @param sessionService - The `StarkSessionService` instance of the application
+	 * @param actions$ The action to perform
+	 * @param sessionService The `StarkSessionService` instance of the application
 	 */
 	public constructor(private actions$: Actions, @Inject(STARK_SESSION_SERVICE) public sessionService: StarkSessionService) {}
 

--- a/packages/stark-core/src/modules/settings/reducers/index.ts
+++ b/packages/stark-core/src/modules/settings/reducers/index.ts
@@ -4,37 +4,29 @@ import { StarkSettingsActions } from "../actions";
 import { settingsReducer } from "./settings.reducer";
 
 /**
- * We define part of the state assigned to the settings module
+ * Defines the part of the state assigned to the {@link StarkSettingsModule}
  */
 export interface StarkSettingsState {
 	/**
-	 * The settings property
-	 * @link StarkSettings
+	 * State corresponding to the {@link StarkSettingsModule}
 	 */
 	settings: StarkSettings;
 }
 
 /**
- * We assign a reducer to our settings property
+ * Reducers assigned to the each property of the {@link StarkSettingsModule}'s state
  */
 export const starkSettingsReducers: ActionReducerMap<StarkSettingsState, StarkSettingsActions> = {
 	/**
-	 * the reducer is assigned to our property
+	 * Reducer assigned to the state's `settings` property
 	 */
 	settings: settingsReducer
 };
 
 /**
- * This will create the session feature used by the selector to find the settings module in the state
- */
-export const selectStarkSettingsFeature: MemoizedSelector<object, StarkSettingsState> = createFeatureSelector<StarkSettingsState>(
-	"StarkSettings"
-);
-
-/**
- * The selector will return the part of the state assigned to the settings when called
+ * NGRX Selector for the {@link StarkSettingsModule}'s state
  */
 export const selectStarkSettings: MemoizedSelector<object, StarkSettings> = createSelector(
-	selectStarkSettingsFeature,
+	createFeatureSelector<StarkSettingsState>("StarkSettings"),
 	(state: StarkSettingsState) => state.settings
 );

--- a/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
+++ b/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
@@ -13,9 +13,9 @@ const INITIAL_STATE: StarkSettings = new StarkSettings();
 
 /**
  * Definition of the settings reducer
- * @param state - the state of the reducer
- * @param action - the action to apply to the reducer
- * @returns a StarkSettings instance
+ * @param state - The state of the reducer
+ * @param action - The action to apply to the reducer
+ * @returns The new `StarkSettings` state
  */
 export function settingsReducer(
 	state: Readonly<StarkSettings> = INITIAL_STATE,

--- a/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
+++ b/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
@@ -5,20 +5,20 @@ import { StarkSettings } from "../entities";
  * Key defined to find the service in a store
  */
 export const starkSettingsStoreKey = "starkSettings";
-/**
- * Defines the initial state of the reducer
- * @link StarkSettings
- */
-const INITIAL_STATE: StarkSettings = new StarkSettings();
 
 /**
- * Definition of the settings reducer
+ * Defines the initial state of the reducer
+ */
+const INITIAL_SETTINGS_STATE: StarkSettings = new StarkSettings();
+
+/**
+ * Definition of the `settings` reducer
  * @param state - The state of the reducer
  * @param action - The action to apply to the reducer
  * @returns The new `StarkSettings` state
  */
 export function settingsReducer(
-	state: Readonly<StarkSettings> = INITIAL_STATE,
+	state: Readonly<StarkSettings> = INITIAL_SETTINGS_STATE,
 	action: Readonly<StarkSettingsActions>
 ): Readonly<StarkSettings> {
 	// the new state will be calculated from the data coming in the actions

--- a/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
+++ b/packages/stark-core/src/modules/settings/reducers/settings.reducer.ts
@@ -13,8 +13,8 @@ const INITIAL_SETTINGS_STATE: StarkSettings = new StarkSettings();
 
 /**
  * Definition of the `settings` reducer
- * @param state - The state of the reducer
- * @param action - The action to apply to the reducer
+ * @param state The state of the reducer
+ * @param action The action to apply to the reducer
  * @returns The new `StarkSettings` state
  */
 export function settingsReducer(

--- a/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
@@ -5,15 +5,13 @@ import { InjectionToken } from "@angular/core";
  */
 export const starkSettingsServiceName = "StarkSettingsService";
 /**
- * Injection Token version of the service name
- * @link InjectionToken
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkSettingsService}
  */
 export const STARK_SETTINGS_SERVICE: InjectionToken<StarkSettingsService> = new InjectionToken<StarkSettingsService>(
 	starkSettingsServiceName
 );
 
 /**
- * Stark Settings Service.
  * Service that allows the manipulation of application settings, some of which can be persisted.
  */
 export interface StarkSettingsService {
@@ -34,7 +32,7 @@ export interface StarkSettingsService {
 	/**
 	 * Gets the preferredLanguage setting
 	 *
-	 * @returns Id of the preferred language
+	 * @returns The id of the preferred language
 	 */
 	getPreferredLanguage(): string;
 

--- a/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
@@ -39,7 +39,7 @@ export interface StarkSettingsService {
 	/**
 	 * Sets the preferredLanguage setting (not persisted)
 	 *
-	 * @param language - Id of the preferred language
+	 * @param language Id of the preferred language
 	 */
 	setPreferredLanguage(language: string): void;
 }

--- a/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.intf.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from "@angular/core";
 
 /**
- * Name of the Settings service, in case injection is needed
+ * Name of the service, in case injection is needed
  */
 export const starkSettingsServiceName = "StarkSettingsService";
 /**
@@ -18,8 +18,8 @@ export interface StarkSettingsService {
 	/**
 	 * Initialize the settings based on the default settings defined following this order:
 	 *
-	 * 1.- Persisted language settings
-	 * 2.- If no persisted language found, AppConfig settings are taken
+	 * 1. Persisted language settings
+	 * 2. If no persisted language found, AppConfig settings are taken
 	 */
 	initializeSettings(): void;
 

--- a/packages/stark-core/src/modules/settings/services/settings.service.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.ts
@@ -18,6 +18,9 @@ import { StarkUser } from "../../user/entities";
 import { StarkCoreApplicationState } from "../../../common/store";
 import { StarkConfigurationUtil } from "../../../util/configuration.util";
 
+/**
+ * @ignore
+ */
 @Injectable()
 export class StarkSettingsServiceImpl implements StarkSettingsService {
 	public preferredLanguage: string;

--- a/packages/stark-core/src/modules/settings/settings.module.ts
+++ b/packages/stark-core/src/modules/settings/settings.module.ts
@@ -12,8 +12,8 @@ export class StarkSettingsModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
 		return {
@@ -24,8 +24,8 @@ export class StarkSettingsModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/settings/settings.module.ts
+++ b/packages/stark-core/src/modules/settings/settings.module.ts
@@ -26,7 +26,7 @@ export class StarkSettingsModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/settings/settings.module.ts
+++ b/packages/stark-core/src/modules/settings/settings.module.ts
@@ -11,8 +11,9 @@ import { StarkSettingsEffects } from "./effects";
 export class StarkSettingsModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @returns A module with providers
 	 */
 	public static forRoot(): ModuleWithProviders {
@@ -24,7 +25,7 @@ export class StarkSettingsModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/user/actions/user.actions.ts
+++ b/packages/stark-core/src/modules/user/actions/user.actions.ts
@@ -20,7 +20,6 @@ export enum StarkUserActionTypes {
 export class StarkFetchUserProfile implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.FETCH_USER_PROFILE = StarkUserActionTypes.FETCH_USER_PROFILE;
 }
@@ -31,7 +30,6 @@ export class StarkFetchUserProfile implements Action {
 export class StarkFetchUserProfileSuccess implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.FETCH_USER_PROFILE_SUCCESS = StarkUserActionTypes.FETCH_USER_PROFILE_SUCCESS;
 
@@ -48,7 +46,6 @@ export class StarkFetchUserProfileSuccess implements Action {
 export class StarkFetchUserProfileFailure implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.FETCH_USER_PROFILE_FAILURE = StarkUserActionTypes.FETCH_USER_PROFILE_FAILURE;
 
@@ -66,7 +63,6 @@ export class StarkFetchUserProfileFailure implements Action {
 export class StarkGetAllUsers implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.GET_ALL_USERS = StarkUserActionTypes.GET_ALL_USERS;
 }
@@ -77,7 +73,6 @@ export class StarkGetAllUsers implements Action {
 export class StarkGetAllUsersSuccess implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.GET_ALL_USERS_SUCCESS = StarkUserActionTypes.GET_ALL_USERS_SUCCESS;
 
@@ -94,7 +89,6 @@ export class StarkGetAllUsersSuccess implements Action {
 export class StarkGetAllUsersFailure implements Action {
 	/**
 	 * The type of Action
-	 * @link StarkUserActionTypes
 	 */
 	public readonly type: StarkUserActionTypes.GET_ALL_USERS_FAILURE = StarkUserActionTypes.GET_ALL_USERS_FAILURE;
 

--- a/packages/stark-core/src/modules/user/actions/user.actions.ts
+++ b/packages/stark-core/src/modules/user/actions/user.actions.ts
@@ -35,7 +35,7 @@ export class StarkFetchUserProfileSuccess implements Action {
 
 	/**
 	 * Class constructor
-	 * @param user - The user fetched from the REST API
+	 * @param user The user fetched from the REST API
 	 */
 	public constructor(public user: StarkUser) {}
 }
@@ -51,7 +51,7 @@ export class StarkFetchUserProfileFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param error - The error that caused the user fetching to fail.
+	 * @param error The error that caused the user fetching to fail.
 	 */
 	public constructor(public error: StarkHttpErrorWrapper | Error) {}
 }
@@ -78,7 +78,7 @@ export class StarkGetAllUsersSuccess implements Action {
 
 	/**
 	 * Class constructor
-	 * @param users - The users retrieved from the the mock data.
+	 * @param users The users retrieved from the the mock data.
 	 */
 	public constructor(public users: StarkUser[]) {}
 }
@@ -94,7 +94,7 @@ export class StarkGetAllUsersFailure implements Action {
 
 	/**
 	 * Class constructor
-	 * @param message - The message describing all the users failure.
+	 * @param message The message describing all the users failure.
 	 */
 	public constructor(public message: string) {}
 }

--- a/packages/stark-core/src/modules/user/entities/user-module-config.entity.intf.ts
+++ b/packages/stark-core/src/modules/user/entities/user-module-config.entity.intf.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from "@angular/core";
 
 /**
- * The InjectionToken version of the config value
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the [StarkUserModuleConfig userProfileResourcePath]{@link StarkUserModuleConfig#userProfileResourcePath}
  */
 export const STARK_USER_PROFILE_RESOURCE_PATH = new InjectionToken<StarkUserModuleConfig["userProfileResourcePath"]>(
 	"StarkUserProfileResourcePath"

--- a/packages/stark-core/src/modules/user/entities/user.entity.ts
+++ b/packages/stark-core/src/modules/user/entities/user.entity.ts
@@ -76,8 +76,8 @@ export class StarkUser implements StarkUserProfile, StarkUserSecurityProfile, St
 	/**
 	 * Extract the properties coming in the "details" object.
 	 * This is a callback method provided by cerialize in order to post-process the de-serialized json object.
-	 * @param instance - Instantiated object with its properties already set as defined via the serializer annotations
-	 * @param json - Raw json object retrieved from the http call
+	 * @param instance Instantiated object with its properties already set as defined via the serializer annotations
+	 * @param json Raw json object retrieved from the http call
 	 */
 	public static OnDeserialized(instance: StarkUser, json: any): void {
 		if (json.details) {

--- a/packages/stark-core/src/modules/user/repository/user.repository.intf.ts
+++ b/packages/stark-core/src/modules/user/repository/user.repository.intf.ts
@@ -8,8 +8,7 @@ import { StarkSingleItemResponseWrapper } from "../../http/entities";
  */
 export const starkUserRepositoryName = "StarkUserRepository";
 /**
- * Injection Token version of the Repository Name
- * @link InjectionToken
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkUserRepository}
  */
 export const STARK_USER_REPOSITORY: InjectionToken<StarkUserRepository> = new InjectionToken<StarkUserRepository>(starkUserRepositoryName);
 
@@ -18,7 +17,7 @@ export const STARK_USER_REPOSITORY: InjectionToken<StarkUserRepository> = new In
  */
 export interface StarkUserRepository {
 	/**
-	 * Fetch the user profile from the back-end
+	 * Fetch the {@link StarkUser} profile from the back-end
 	 */
 	getUser(): Observable<StarkSingleItemResponseWrapper<StarkUser>>;
 }

--- a/packages/stark-core/src/modules/user/services/user.service.intf.ts
+++ b/packages/stark-core/src/modules/user/services/user.service.intf.ts
@@ -7,7 +7,7 @@ import { StarkUser } from "../entities";
  */
 export const starkUserServiceName = "StarkUserService";
 /**
- * InjectionToken version of the service name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkUserService}
  */
 export const STARK_USER_SERVICE: InjectionToken<StarkUserService> = new InjectionToken<StarkUserService>(starkUserServiceName);
 
@@ -18,19 +18,17 @@ export const STARK_USER_SERVICE: InjectionToken<StarkUserService> = new Injectio
  */
 export interface StarkUserService {
 	/**
-	 * Triggers an HTTP call to the REST API to fetch the user profile
+	 * Triggers an HTTP call to the REST API to fetch the {@link StarkUser} profile
 	 *
-	 * @link StarkUser
-	 * @returns Observable that will emit the user profile fetched from the REST API
+	 * @returns Observable that will emit the `StarkUser` profile fetched from the REST API
 	 */
 	fetchUserProfile(): Observable<StarkUser>;
 
 	/**
-	 * Gets all user profiles defined in the mock data (to be used only in development).
+	 * Gets all {@link StarkUser} profiles defined in the mock data (to be used only in development).
 	 * This only makes sense during development, where user profiles and the profile selection screen are necessary
 	 *
-	 * @link StarkUser
-	 * @returns Observable that will emit the user profiles defined in the mock data
+	 * @returns Observable that will emit the `StarkUser` profiles defined in the mock data
 	 */
 	getAllUsers(): StarkUser[];
 }

--- a/packages/stark-core/src/modules/user/services/user.service.intf.ts
+++ b/packages/stark-core/src/modules/user/services/user.service.intf.ts
@@ -3,7 +3,7 @@ import { Observable } from "rxjs";
 import { StarkUser } from "../entities";
 
 /**
- * Name of the User service, in case injection is needed
+ * Name of the service, in case injection is needed
  */
 export const starkUserServiceName = "StarkUserService";
 /**

--- a/packages/stark-core/src/modules/user/user.module.ts
+++ b/packages/stark-core/src/modules/user/user.module.ts
@@ -7,8 +7,9 @@ import { STARK_USER_REPOSITORY, StarkUserRepositoryImpl } from "./repository";
 export class StarkUserModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @param userModuleConfig - Object containing the configuration (if any) for the `StarkUserModule`
 	 * @returns A module with providers
 	 */
@@ -25,7 +26,7 @@ export class StarkUserModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 */
 	public constructor(

--- a/packages/stark-core/src/modules/user/user.module.ts
+++ b/packages/stark-core/src/modules/user/user.module.ts
@@ -8,9 +8,9 @@ export class StarkUserModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @param userModuleConfig - Object containing the configuration (if any) for the User Module
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @param userModuleConfig - Object containing the configuration (if any) for the `StarkUserModule`
+	 * @returns A module with providers
 	 */
 	public static forRoot(userModuleConfig?: StarkUserModuleConfig): ModuleWithProviders {
 		return {
@@ -25,8 +25,8 @@ export class StarkUserModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/user/user.module.ts
+++ b/packages/stark-core/src/modules/user/user.module.ts
@@ -10,7 +10,7 @@ export class StarkUserModule {
 	 * so the `forRoot()` should be called only by the `AppModule`.
 	 *
 	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
-	 * @param userModuleConfig - Object containing the configuration (if any) for the `StarkUserModule`
+	 * @param userModuleConfig Object containing the configuration (if any) for the `StarkUserModule`
 	 * @returns A module with providers
 	 */
 	public static forRoot(userModuleConfig?: StarkUserModuleConfig): ModuleWithProviders {
@@ -27,7 +27,7 @@ export class StarkUserModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
+	 * @param parentModule The parent module
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
+++ b/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
@@ -5,16 +5,21 @@ import { tap } from "rxjs/operators";
 import { STARK_XSRF_SERVICE, StarkXSRFService } from "../services/xsrf.service.intf";
 
 /**
- * Angular Http interceptor that adds the XSRF configuration to every state-changing request (POST,PUT,PATCH and DELETE)
+ * Angular Http interceptor that adds the XSRF configuration to every state-changing request (POST, PUT, PATCH and DELETE)
  * and stores the XSRF token from every response.
  *
- * Defined in the HttpClientXsrfModule set in packages/stark-core/src/modules/http/http.module.ts
+ * Defined in the {@link StarkXSRFModule}
  */
 @Injectable()
 export class StarkXSRFHttpInterceptor implements HttpInterceptor {
+	/**
+	 * Class constructor
+	 * @param xsrfService - The application's StarkXSRFService instance
+	 */
 	public constructor(@Inject(STARK_XSRF_SERVICE) public xsrfService: StarkXSRFService) {}
 
 	/**
+	 * Intercepts the outgoing {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest}
 	 * @param request - The intercepted outgoing `HttpRequest`
 	 * @param next - The next request handler where the `HttpRequest` will be forwarded to
 	 * @returns The modified `HttpRequest` with the XSRF configuration enabled.

--- a/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
+++ b/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
@@ -14,14 +14,14 @@ import { STARK_XSRF_SERVICE, StarkXSRFService } from "../services/xsrf.service.i
 export class StarkXSRFHttpInterceptor implements HttpInterceptor {
 	/**
 	 * Class constructor
-	 * @param xsrfService - The application's StarkXSRFService instance
+	 * @param xsrfService The application's StarkXSRFService instance
 	 */
 	public constructor(@Inject(STARK_XSRF_SERVICE) public xsrfService: StarkXSRFService) {}
 
 	/**
 	 * Intercepts the outgoing {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest}
-	 * @param request - The intercepted outgoing `HttpRequest`
-	 * @param next - The next request handler where the `HttpRequest` will be forwarded to
+	 * @param request The intercepted outgoing `HttpRequest`
+	 * @param next The next request handler where the `HttpRequest` will be forwarded to
 	 * @returns The modified `HttpRequest` with the XSRF configuration enabled.
 	 */
 	public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {

--- a/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
+++ b/packages/stark-core/src/modules/xsrf/interceptors/http-xsrf.interceptor.ts
@@ -30,7 +30,7 @@ export class StarkXSRFHttpInterceptor implements HttpInterceptor {
 		return next
 			.handle(xsrfProtectedRequest) // pass request through to the next request handler
 			.pipe(
-				// the Http response is intercepted in order to extract and store the XSRF token via the XSRF service
+				// the Http response is intercepted in order to extract and store the XSRF token via the StarkXSRFService
 				tap((_httpResponse: HttpEvent<any>) => {
 					this.xsrfService.storeXSRFToken();
 				})

--- a/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
@@ -11,23 +11,23 @@ export const STARK_XSRF_CONFIG: InjectionToken<StarkXSRFConfig> = new InjectionT
  */
 export interface StarkXSRFWaitBeforePingingLiteral {
 	/**
-	 * Array of Dependency Injection tokens for the dependencies of the waitBeforePingingFn.
+	 * Array of Dependency Injection tokens for the dependencies of the `waitBeforePingingFn`.
 	 */
 	deps: any[];
 
 	/**
-	 * Function that will be called by the XSRF service passing the necessary dependencies to get the corresponding Promise/Observable
+	 * Function that will be called by the {@link StarkXSRFService} passing the necessary dependencies to get the corresponding Promise/Observable
 	 * that the service should wait for before pinging all the backends.
 	 */
 	waitBeforePingingFn: (...deps: any[]) => Promise<any> | PromiseLike<any> | Observable<any>;
 }
 
 /**
- * Definition of the configuration object for the Stark XSRF service
+ * Definition of the configuration object for the Stark  {@link StarkXSRFService}
  */
 export interface StarkXSRFConfig {
 	/**
-	 * Function that will be called by the XSRF service to get the corresponding Promise/Observable
+	 * Function that will be called by the {@link StarkXSRFService} to get the corresponding Promise/Observable
 	 * that the service should wait for before pinging all the backends.
 	 * Alternatively, this can be defined as a {@link StarkXSRFWaitBeforePingingLiteral|literal}
 	 */

--- a/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from "@angular/core";
 import { Observable } from "rxjs";
 
 /**
- * The InjectionToken version of the config name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkXSRFConfig}
  */
 export const STARK_XSRF_CONFIG: InjectionToken<StarkXSRFConfig> = new InjectionToken<StarkXSRFConfig>("StarkXSRFConfig");
 

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
@@ -23,7 +23,7 @@ export interface StarkXSRFService {
 	 *
 	 * This method should be used for those HTTP "state-changing" requests (POST, PUT, PATCH or DELETE) which are not performed
 	 * using StarkHttpService or Angular raw $http
-	 * @param xhr - The XHR object to be configured
+	 * @param xhr The XHR object to be configured
 	 */
 	configureXHR(xhr: XMLHttpRequest): void;
 
@@ -32,7 +32,7 @@ export interface StarkXSRFService {
 	 * for "state-changing" requests (POST, PUT, PATCH or DELETE) in order to enable XSRF protection.
 	 *
 	 * Logs a warning whenever there is no XSRF token to be sent in such requests
-	 * @param request - The Angular `HttpRequest` to be modified
+	 * @param request The Angular `HttpRequest` to be modified
 	 * @returns The modified Angular `HttpRequest`
 	 */
 	configureHttpRequest(request: HttpRequest<any>): HttpRequest<any>;

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
@@ -20,15 +20,17 @@ export interface StarkXSRFService {
 	 * Add the necessary options to the XHR config in order to enable XSRF protection.
 	 * Since the service will add the XSRF header to the XHR object, this method must be called after calling the XHR open() method because
 	 * headers cannot be set before open(). See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader
-	 * This method should be used for those HTTP state-changing requests (POST, PUT, PATCH or DELETE) which are not performed
+	 *
+	 * This method should be used for those HTTP "state-changing" requests (POST, PUT, PATCH or DELETE) which are not performed
 	 * using StarkHttpService or Angular raw $http
 	 * @param xhr - The XHR object to be configured
 	 */
 	configureXHR(xhr: XMLHttpRequest): void;
 
 	/**
-	 * Return a new {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest} including the necessary options for state-changing requests (POST, PUT, PATCH or DELETE)
-	 * in order to enable XSRF protection.
+	 * Return a new {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest} including the necessary options
+	 * for "state-changing" requests (POST, PUT, PATCH or DELETE) in order to enable XSRF protection.
+	 *
 	 * Logs a warning whenever there is no XSRF token to be sent in such requests
 	 * @param request - The Angular `HttpRequest` to be modified
 	 * @returns The modified Angular `HttpRequest`

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.intf.ts
@@ -6,13 +6,14 @@ import { HttpRequest } from "@angular/common/http";
  */
 export const starkXSRFServiceName = "StarkXSRFService";
 /**
- * The InjectionToken version of the service name
+ * {@link https://v7.angular.io/api/core/InjectionToken|InjectionToken} used to provide the {@link StarkXSRFService}
  */
 export const STARK_XSRF_SERVICE: InjectionToken<StarkXSRFService> = new InjectionToken<StarkXSRFService>(starkXSRFServiceName);
 
 /**
  * Stark XSRF Service.
  * Service to get/store the XSRF token to be used with the different backends.
+ * It also adds the XSRF configuration to XHR objects for those HTTP requests not performed using StarkHttpService or Angular's HttpClient.
  */
 export interface StarkXSRFService {
 	/**
@@ -26,7 +27,7 @@ export interface StarkXSRFService {
 	configureXHR(xhr: XMLHttpRequest): void;
 
 	/**
-	 * Return a new `HttpRequest` including the necessary options for state-changing requests (POST, PUT, PATCH or DELETE)
+	 * Return a new {@link https://v7.angular.io/api/common/http/HttpRequest|HttpRequest} including the necessary options for state-changing requests (POST, PUT, PATCH or DELETE)
 	 * in order to enable XSRF protection.
 	 * Logs a warning whenever there is no XSRF token to be sent in such requests
 	 * @param request - The Angular `HttpRequest` to be modified

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.ts
@@ -14,10 +14,8 @@ import { StarkBackend, StarkHttpErrorWrapper, StarkHttpErrorWrapperImpl } from "
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "../../logging/services/logging.service.intf";
 
 /**
- * Service to get/store the XSRF token to be used with the different backends.
- * It also adds the XSRF configuration to XHR objects for those HTTP requests not performed using StarkHttpService or Angular's HttpClient.
- *
- * @dynamic See: https://angular.io/guide/aot-compiler#strictmetadataemit
+ * @ignore
+ * @dynamic See: https://v7.angular.io/guide/aot-compiler#strictmetadataemit
  */
 @Injectable()
 export class StarkXSRFServiceImpl implements StarkXSRFService {
@@ -72,7 +70,7 @@ export class StarkXSRFServiceImpl implements StarkXSRFService {
 					headers: newHeaders,
 					// Enforce the 'withCredentials' property flag on every XHR object created by Angular $http.
 					// We leverage "credentialed" requests that are aware of HTTP cookies (necessary for XSRF to work with multiple backends)
-					// https://angular.io/api/common/http/HttpRequest#withCredentials
+					// https://v7.angular.io/api/common/http/HttpRequest#withCredentials
 					// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Requests_with_credentials
 					withCredentials: true
 				});
@@ -80,7 +78,7 @@ export class StarkXSRFServiceImpl implements StarkXSRFService {
 		}
 
 		// in any case the "withCredentials: true" should be added to ALL requests, otherwise the browser won't accept the XSRF cookie from the backend!
-		// see: https://angular.io/api/common/http/HttpRequest#withCredentials
+		// see: https://v7.angular.io/api/common/http/HttpRequest#withCredentials
 		// see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Requests_with_credentials
 		return request.clone({ withCredentials: true });
 	}
@@ -192,7 +190,8 @@ export class StarkXSRFServiceImpl implements StarkXSRFService {
 		this.document.cookie = cookieAttributes.join(";");
 	}
 
-	// code taken from ngx-cookie-service library (https://github.com/7leads/ngx-cookie-service/blob/master/lib/cookie-service/cookie.service.ts)
+	// code taken from ngx-cookie-service library
+	// see https://github.com/stevermeister/ngx-cookie-service/blob/master/projects/ngx-cookie-service/src/lib/cookie.service.ts
 	protected getXSRFCookie(): string | undefined {
 		const cookieRegExp: RegExp = this.getCookieRegExp(encodeURIComponent(this.xsrfCookieName));
 		const result: RegExpExecArray | null = cookieRegExp.exec(this.document.cookie);

--- a/packages/stark-core/src/modules/xsrf/xsrf.module.ts
+++ b/packages/stark-core/src/modules/xsrf/xsrf.module.ts
@@ -24,7 +24,7 @@ export class StarkXSRFModule {
 	 * so the `forRoot()` should be called only by the `AppModule`.
 	 *
 	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
-	 * @param xsrfConfig - Object containing the configuration (if any) for the `StarkXSRFService`
+	 * @param xsrfConfig Object containing the configuration (if any) for the `StarkXSRFService`
 	 * @returns A module with providers
 	 */
 	public static forRoot(xsrfConfig?: StarkXSRFConfig): ModuleWithProviders {
@@ -41,9 +41,9 @@ export class StarkXSRFModule {
 	/**
 	 * Prevents this module from being re-imported
 	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
-	 * @param parentModule - The parent module
-	 * @param xsrfService - The `StarkXSRFService` instance of the application.
-	 * @param appInitStatus - A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
+	 * @param parentModule The parent module
+	 * @param xsrfService The `StarkXSRFService` instance of the application.
+	 * @param appInitStatus A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/modules/xsrf/xsrf.module.ts
+++ b/packages/stark-core/src/modules/xsrf/xsrf.module.ts
@@ -21,8 +21,9 @@ import { StarkXSRFHttpInterceptor } from "./interceptors";
 export class StarkXSRFModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
-	 * so the forRoot() should be called only by the AppModule
-	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * so the `forRoot()` should be called only by the `AppModule`.
+	 *
+	 * See {@link https://v7.angular.io/guide/singleton-services#the-forroot-pattern|Angular docs: The forRoot() pattern}
 	 * @param xsrfConfig - Object containing the configuration (if any) for the `StarkXSRFService`
 	 * @returns A module with providers
 	 */
@@ -39,7 +40,7 @@ export class StarkXSRFModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * See {@link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule|Angular docs: Prevent reimport of a root module}
 	 * @param parentModule - The parent module
 	 * @param xsrfService - The `StarkXSRFService` instance of the application.
 	 * @param appInitStatus - A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.

--- a/packages/stark-core/src/modules/xsrf/xsrf.module.ts
+++ b/packages/stark-core/src/modules/xsrf/xsrf.module.ts
@@ -10,10 +10,10 @@ import { StarkXSRFHttpInterceptor } from "./interceptors";
 		HttpClientModule,
 		HttpClientXsrfModule.withOptions({
 			// Name of cookie containing the XSRF token. Default value in Angular is 'XSRF-TOKEN'
-			// https://angular.io/guide/http#security-xsrf-protection
+			// https://v7.angular.io/guide/http#security-xsrf-protection
 			cookieName: "XSRF-TOKEN",
 			// Name of HTTP header to populate with the XSRF token. Default value in Angular is 'X-XSRF-TOKEN'.
-			// https://angular.io/guide/http#security-xsrf-protection
+			// https://v7.angular.io/guide/http#security-xsrf-protection
 			headerName: StarkHttpHeaders.XSRF_TOKEN
 		})
 	]
@@ -22,9 +22,9 @@ export class StarkXSRFModule {
 	/**
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
-	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @param xsrfConfig - Object containing the configuration (if any) for the XSRF service
-	 * @returns a module with providers
+	 * @link https://v7.angular.io/guide/singleton-services#the-forroot-pattern
+	 * @param xsrfConfig - Object containing the configuration (if any) for the `StarkXSRFService`
+	 * @returns A module with providers
 	 */
 	public static forRoot(xsrfConfig?: StarkXSRFConfig): ModuleWithProviders {
 		return {
@@ -39,10 +39,10 @@ export class StarkXSRFModule {
 
 	/**
 	 * Prevents this module from being re-imported
-	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	 * @param parentModule - the parent module
-	 * @param xsrfService - The XSRF service of the application
-	 * @param appInitStatus - A class that reflects the state of running {@link APP_INITIALIZER}s.
+	 * @link https://v7.angular.io/guide/singleton-services#prevent-reimport-of-the-greetingmodule
+	 * @param parentModule - The parent module
+	 * @param xsrfService - The `StarkXSRFService` instance of the application.
+	 * @param appInitStatus - A class that reflects the state of running {@link https://v7.angular.io/api/core/APP_INITIALIZER|APP_INITIALIZER}s.
 	 */
 	public constructor(
 		@Optional()

--- a/packages/stark-core/src/serialization/string-map.ts
+++ b/packages/stark-core/src/serialization/string-map.ts
@@ -5,7 +5,7 @@ import { Deserialize, ISerializable, Serialize } from "cerialize";
  * in this way the custom behavior for handling ES6 Maps is defined once instead of doing it every time a Map is used
  * @link https://github.com/weichx/cerialize/issues/32
  * @link https://github.com/weichx/cerialize/issues/33
- * @param targetType - the type in which we want to serialize a file
+ * @param targetType - The type in which we want to serialize a file
  */
 export const stringMap: Function = (targetType: any): ISerializable => {
 	return {

--- a/packages/stark-core/src/serialization/string-map.ts
+++ b/packages/stark-core/src/serialization/string-map.ts
@@ -1,10 +1,12 @@
 import { Deserialize, ISerializable, Serialize } from "cerialize";
 
 /**
- * Solution proposed by @weichx for Maps having string keys
- * in this way the custom behavior for handling ES6 Maps is defined once instead of doing it every time a Map is used
- * @link https://github.com/weichx/cerialize/issues/32
- * @link https://github.com/weichx/cerialize/issues/33
+ * Solution proposed by `@weichx` for Maps having string keys
+ * in this way the custom behavior for handling ES6 Maps is defined once instead of doing it every time a Map is used.
+ *
+ * See:
+ * - {@link https://github.com/weichx/cerialize/issues/32}
+ * - {@link https://github.com/weichx/cerialize/issues/33}
  * @param targetType - The type in which we want to serialize a file
  */
 export const stringMap: Function = (targetType: any): ISerializable => {

--- a/packages/stark-core/src/serialization/string-map.ts
+++ b/packages/stark-core/src/serialization/string-map.ts
@@ -7,7 +7,7 @@ import { Deserialize, ISerializable, Serialize } from "cerialize";
  * See:
  * - {@link https://github.com/weichx/cerialize/issues/32}
  * - {@link https://github.com/weichx/cerialize/issues/33}
- * @param targetType - The type in which we want to serialize a file
+ * @param targetType The type in which we want to serialize a file
  */
 export const stringMap: Function = (targetType: any): ISerializable => {
 	return {

--- a/packages/stark-core/src/util/configuration.util.ts
+++ b/packages/stark-core/src/util/configuration.util.ts
@@ -12,9 +12,9 @@ export type StarkMetadataValidationGroups = "settings";
 export class StarkConfigurationUtil {
 	/**
 	 * Validates the given AppConfig instance and throws an error in case it is not valid
-	 * @param appConfig - The AppConfig instance to be validated
-	 * @param groups - The groups to be used for validating the config
-	 * @param errorMessagePrefix - The prefix to be added to the error message in case the config is not valid
+	 * @param appConfig The AppConfig instance to be validated
+	 * @param groups The groups to be used for validating the config
+	 * @param errorMessagePrefix The prefix to be added to the error message in case the config is not valid
 	 */
 	public static validateConfig(
 		appConfig: StarkApplicationConfig,
@@ -31,9 +31,9 @@ export class StarkConfigurationUtil {
 
 	/**
 	 * Validates the given AppMetadata instance and throws an error in case it is not valid
-	 * @param appMetadata - The AppMetadata instance to be validated
-	 * @param groups - The groups to be used for validating the config
-	 * @param errorMessagePrefix - The prefix to be added to the error message in case the config is not valid
+	 * @param appMetadata The AppMetadata instance to be validated
+	 * @param groups The groups to be used for validating the config
+	 * @param errorMessagePrefix The prefix to be added to the error message in case the config is not valid
 	 */
 	public static validateMetadata(
 		appMetadata: StarkApplicationMetadata,

--- a/packages/stark-core/src/util/date.util.ts
+++ b/packages/stark-core/src/util/date.util.ts
@@ -1,16 +1,19 @@
 import moment from "moment";
 
 /**
- * Util class used to parse and format Date objects.
+ * Util class used to parse and format `Date` objects.
  */
 export class StarkDateUtil {
 	/**
 	 * Returns a Date object when the specified dateString is a valid date according to the specified format,
-	 * otherwise it returns undefined
+	 * otherwise it returns `undefined`.
+	 *
 	 * A valid date can be an actual Date object or a string matching the specified format.
+	 *
+	 * Supported formats are those specified in the {@link https://momentjs.com/docs/#/parsing/string-format/|Moment.js API docs: parse string format}
+	 *
 	 * @param dateString - A valid ISO 8601 string or a custom one aligned to the format provided
-	 * @param format - A valid format string according to moment API docs (see link)
-	 * @link http://momentjs.com/docs/#/parsing/string-format/
+	 * @param format - A valid format string according to Moment.js API docs
 	 */
 	public static parseDateWithFormat(dateString: string, format: string): Date | undefined {
 		if (moment(dateString, format).isValid()) {
@@ -21,10 +24,12 @@ export class StarkDateUtil {
 	}
 
 	/**
-	 * Returns the specified date as a string with the given format
+	 * Returns the specified date as a string with the given format.
+	 *
+	 * Supported formats are those specified in the {@link https://momentjs.com/docs/#/displaying/format/|Moment.js API docs: display format}
+	 *
 	 * @param date - A Date object to be formatted
-	 * @param format - A valid format string according to the moment API docs (see link)
-	 * @link https://momentjs.com/docs/#/displaying/format/
+	 * @param format - A valid format string according to the Moment.js API docs
 	 */
 	public static format(date: Date, format: string = "DD-MM-YYYY"): string {
 		let formattedDate = "invalid date";

--- a/packages/stark-core/src/util/date.util.ts
+++ b/packages/stark-core/src/util/date.util.ts
@@ -12,8 +12,8 @@ export class StarkDateUtil {
 	 *
 	 * Supported formats are those specified in the {@link https://momentjs.com/docs/#/parsing/string-format/|Moment.js API docs: parse string format}
 	 *
-	 * @param dateString - A valid ISO 8601 string or a custom one aligned to the format provided
-	 * @param format - A valid format string according to Moment.js API docs
+	 * @param dateString A valid ISO 8601 string or a custom one aligned to the format provided
+	 * @param format A valid format string according to Moment.js API docs
 	 */
 	public static parseDateWithFormat(dateString: string, format: string): Date | undefined {
 		if (moment(dateString, format).isValid()) {
@@ -28,8 +28,8 @@ export class StarkDateUtil {
 	 *
 	 * Supported formats are those specified in the {@link https://momentjs.com/docs/#/displaying/format/|Moment.js API docs: display format}
 	 *
-	 * @param date - A Date object to be formatted
-	 * @param format - A valid format string according to the Moment.js API docs
+	 * @param date A Date object to be formatted
+	 * @param format A valid format string according to the Moment.js API docs
 	 */
 	public static format(date: Date, format: string = "DD-MM-YYYY"): string {
 		let formattedDate = "invalid date";

--- a/packages/stark-core/src/util/http.util.ts
+++ b/packages/stark-core/src/util/http.util.ts
@@ -11,13 +11,13 @@ import reduce from "lodash-es/reduce";
 export const STARK_HTTP_PARAM_ENCODER: HttpParameterCodec = new StarkHttpParameterCodec();
 
 /**
- * Util class used for the HTTP module
- * @dynamic See: https://angular.io/guide/aot-compiler#strictmetadataemit
+ * Util class used for the {@link StarkHttpModule}
+ * @dynamic See: https://v7.angular.io/guide/aot-compiler#strictmetadataemit
  */
 export class StarkHttpUtil {
 	/**
 	 * Converts the Map<string, StarkQueryParam> required by the service into a HttpParams object required by Angular
-	 * @param starkQueryParam - params to convert
+	 * @param starkQueryParam - Params to convert
 	 */
 	public static convertStarkQueryParamsIntoHttpParams(starkQueryParam: Map<string, StarkQueryParam>): HttpParams {
 		return reduce(

--- a/packages/stark-core/src/util/http.util.ts
+++ b/packages/stark-core/src/util/http.util.ts
@@ -5,8 +5,10 @@ import { convertMapIntoObject } from "./util-helpers";
 import reduce from "lodash-es/reduce";
 
 /**
- * A custom implementation of HttpParameterCodec to correctly encode query parameters.
- * @link https://github.com/NationalBankBelgium/stark/issues/1130
+ * An instance of the {@link StarkHttpParameterCodec} which is internally used by
+ * the [StarkHttpUtil convertStarkQueryParamsIntoHttpParams]{@link StarkHttpUtil#convertStarkQueryParamsIntoHttpParams} method.
+ *
+ * See {@link https://github.com/NationalBankBelgium/stark/issues/1130}
  */
 export const STARK_HTTP_PARAM_ENCODER: HttpParameterCodec = new StarkHttpParameterCodec();
 
@@ -16,7 +18,7 @@ export const STARK_HTTP_PARAM_ENCODER: HttpParameterCodec = new StarkHttpParamet
  */
 export class StarkHttpUtil {
 	/**
-	 * Converts the Map<string, StarkQueryParam> required by the service into a HttpParams object required by Angular
+	 * Converts the `Map<string, StarkQueryParam>` required by the {@link StarkHttpService} into a `HttpParams` object required by Angular
 	 * @param starkQueryParam - Params to convert
 	 */
 	public static convertStarkQueryParamsIntoHttpParams(starkQueryParam: Map<string, StarkQueryParam>): HttpParams {

--- a/packages/stark-core/src/util/http.util.ts
+++ b/packages/stark-core/src/util/http.util.ts
@@ -19,7 +19,7 @@ export const STARK_HTTP_PARAM_ENCODER: HttpParameterCodec = new StarkHttpParamet
 export class StarkHttpUtil {
 	/**
 	 * Converts the `Map<string, StarkQueryParam>` required by the {@link StarkHttpService} into a `HttpParams` object required by Angular
-	 * @param starkQueryParam - Params to convert
+	 * @param starkQueryParam Params to convert
 	 */
 	public static convertStarkQueryParamsIntoHttpParams(starkQueryParam: Map<string, StarkQueryParam>): HttpParams {
 		return reduce(

--- a/packages/stark-core/src/util/url-util.ts
+++ b/packages/stark-core/src/util/url-util.ts
@@ -4,7 +4,7 @@
 export class StarkUrlUtil {
 	/**
 	 * Extracts all the expected parameters defined in the URL. These are defined by a placeholder like ":paramName".
-	 * @param url - The URL containing the placeholders for URL parameters.
+	 * @param url The URL containing the placeholders for URL parameters.
 	 * @returns An array containing all the expected parameters defined in the URL (the placeholders ":paramName" that are present in the URL)
 	 */
 	public static parseUrlParams(url: string): string[] {
@@ -23,8 +23,8 @@ export class StarkUrlUtil {
 
 	/**
 	 * Interpolates the URL params with the given parameters object. It replaces the params placeholders with their corresponding values.
-	 * @param url - The URL containing the placeholders for URL parameters.
-	 * @param params - Object containing params name-value pairs to be replaced in the URL
+	 * @param url The URL containing the placeholders for URL parameters.
+	 * @param params Object containing params name-value pairs to be replaced in the URL
 	 * @returns The final URL with the parameters placeholders replaced by their corresponding values
 	 */
 	public static interpolateUrlWithParams(url: string, params: { [param: string]: string }): string {

--- a/packages/stark-core/src/util/util-helpers.ts
+++ b/packages/stark-core/src/util/util-helpers.ts
@@ -1,6 +1,6 @@
 /**
  * Converts a map (used for params and headers) into a plain object
- * @param map - the Map to convert
+ * @param map - The Map to convert
  */
 export function convertMapIntoObject(map: Map<string, any>): { [param: string]: any } {
 	const resultObj: { [param: string]: any } = {};

--- a/packages/stark-core/src/util/util-helpers.ts
+++ b/packages/stark-core/src/util/util-helpers.ts
@@ -1,6 +1,6 @@
 /**
  * Converts a map (used for params and headers) into a plain object
- * @param map - The Map to convert
+ * @param map The Map to convert
  */
 export function convertMapIntoObject(map: Map<string, any>): { [param: string]: any } {
 	const resultObj: { [param: string]: any } = {};

--- a/packages/stark-core/src/util/validation-class.util.ts
+++ b/packages/stark-core/src/util/validation-class.util.ts
@@ -1,9 +1,9 @@
 /**
- * Class containing utils to be used for class validation decorators of the 'class-validator' library
+ * Class containing utils to be used for class validation decorators of the {@link https://github.com/typestack/class-validator|class-validator} library
  */
 export class StarkClassValidationUtil {
 	/**
-	 * Returns true if the given value is NOT undefined.
+	 * Returns `true` if the given value is **not** `undefined`.
 	 * @param _instance - The instance of the class being validated
 	 * @param value - The value of the property being validated
 	 */
@@ -12,7 +12,7 @@ export class StarkClassValidationUtil {
 	}
 
 	/**
-	 * Returns true if the given value is NOT undefined and NOT null.
+	 * Returns `true` if the given value is **not** `undefined` and **not** `null`.
 	 * @param _instance - The instance of the class being validated
 	 * @param value - The value of the property being validated
 	 */

--- a/packages/stark-core/src/util/validation-class.util.ts
+++ b/packages/stark-core/src/util/validation-class.util.ts
@@ -4,8 +4,8 @@
 export class StarkClassValidationUtil {
 	/**
 	 * Returns `true` if the given value is **not** `undefined`.
-	 * @param _instance - The instance of the class being validated
-	 * @param value - The value of the property being validated
+	 * @param _instance The instance of the class being validated
+	 * @param value The value of the property being validated
 	 */
 	public static validateIfDefined(_instance: any, value: any): boolean {
 		return typeof value !== "undefined";
@@ -13,8 +13,8 @@ export class StarkClassValidationUtil {
 
 	/**
 	 * Returns `true` if the given value is **not** `undefined` and **not** `null`.
-	 * @param _instance - The instance of the class being validated
-	 * @param value - The value of the property being validated
+	 * @param _instance The instance of the class being validated
+	 * @param value The value of the property being validated
 	 */
 	public static validateIfDefinedAndNotNull(_instance: any, value: any): boolean {
 		return typeof value !== "undefined" && value !== null;

--- a/packages/stark-core/src/util/validation-errors.util.ts
+++ b/packages/stark-core/src/util/validation-errors.util.ts
@@ -6,8 +6,8 @@ import { ValidationError } from "class-validator";
 export class StarkValidationErrorsUtil {
 	/**
 	 * Throws an error in case there are  validation errors. The error contains the description of the different errors.
-	 * @param validationErrors - Array containing validation results
-	 * @param errorMessagePrefix - (Optional) A prefix to be added to the error message
+	 * @param validationErrors Array containing validation results
+	 * @param errorMessagePrefix (Optional) A prefix to be added to the error message
 	 * @throws Error
 	 */
 	public static throwOnError(validationErrors: ValidationError[], errorMessagePrefix?: string): void {
@@ -21,8 +21,8 @@ export class StarkValidationErrorsUtil {
 
 	/**
 	 * Extracts the description of all the validation errors and generates a single string containing such descriptions
-	 * @param validationErrors - Array containing validation results
-	 * @param errorMessagePrefix - (Optional) A prefix to be added to the generated string
+	 * @param validationErrors Array containing validation results
+	 * @param errorMessagePrefix (Optional) A prefix to be added to the generated string
 	 */
 	// FIXME: re-enable this TSLINT rule and refactor this function to reduce its cognitive complexity
 	// tslint:disable-next-line:cognitive-complexity

--- a/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsBICValidatorName } from "../../validators/is-bic";
 class StarkIsBICConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a give BIC address is valid
-	 * @param bic - the bic to validate
-	 * @returns boolean - true if the bic has been validated
+	 * @param bic - The bic to validate
+	 * @returns `true` if the bic has been validated
 	 */
 	public validate(bic: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -22,7 +22,7 @@ class StarkIsBICConstraint implements ValidatorConstraintInterface {
 
 	/**
 	 * Default message displayed if the BIC address is not valid
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid BIC address";

--- a/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsBICValidatorName } from "../../validators/is-bic";
 class StarkIsBICConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a give BIC address is valid
-	 * @param bic - The bic to validate
+	 * @param bic The bic to validate
 	 * @returns `true` if the bic has been validated
 	 */
 	public validate(bic: string): boolean {
@@ -31,7 +31,7 @@ class StarkIsBICConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsBIC validator constraint
- * @param validationOptions - The options used for validation
+ * @param validationOptions The options used for validation
  * @returns Function
  */
 export function StarkIsBIC(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsCompanyNumberValidatorName } from "../../validators/is-company-n
 class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given Company number is valid
-	 * @param companyNumber - the number to validate
-	 * @returns boolean - true if the company number is valid or not
+	 * @param companyNumber - The number to validate
+	 * @returns `true` if the company number is valid or not
 	 */
 	public validate(companyNumber: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -22,7 +22,7 @@ class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterface {
 
 	/**
 	 * Default message displayed if the Company number is not valid
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid company number";

--- a/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsCompanyNumberValidatorName } from "../../validators/is-company-n
 class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given Company number is valid
-	 * @param companyNumber - The number to validate
+	 * @param companyNumber The number to validate
 	 * @returns `true` if the company number is valid or not
 	 */
 	public validate(companyNumber: string): boolean {

--- a/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsEstablishmentUnitNumberValidatorName } from "../../validators/is
 class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given Establishment number provided is valid
-	 * @param establishmentNumber - the establishment number to validate
-	 * @returns boolean - true if the establishment number is valida
+	 * @param establishmentNumber - The establishment number to validate
+	 * @returns `true` if the establishment number is valida
 	 */
 	public validate(establishmentNumber: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -23,7 +23,7 @@ class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInt
 
 	/**
 	 * Default Message displayed if the Establishment number is not valid
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid Establishment number";
@@ -32,7 +32,7 @@ class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInt
 
 /**
  * Validator decorator that uses the StarkIsIsEstablishmentUnitNumber validator constraint
- * @param validationOptions - the options that will define the validity of the establishment number
+ * @param validationOptions - The options that will define the validity of the establishment number
  * @returns Function
  */
 export function StarkIsEstablishmentUnitNumber(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsEstablishmentUnitNumberValidatorName } from "../../validators/is
 class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given Establishment number provided is valid
-	 * @param establishmentNumber - The establishment number to validate
+	 * @param establishmentNumber The establishment number to validate
 	 * @returns `true` if the establishment number is valida
 	 */
 	public validate(establishmentNumber: string): boolean {
@@ -32,7 +32,7 @@ class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInt
 
 /**
  * Validator decorator that uses the StarkIsIsEstablishmentUnitNumber validator constraint
- * @param validationOptions - The options that will define the validity of the establishment number
+ * @param validationOptions The options that will define the validity of the establishment number
  * @returns Function
  */
 export function StarkIsEstablishmentUnitNumber(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsIBANValidatorName } from "../../validators/is-iban";
 class StarkIsIBANConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given IBAN number is valid
-	 * @param iban - the iban to validate
-	 * @returns boolean - true if the iban is valid
+	 * @param iban - The iban to validate
+	 * @returns `true` if the iban is valid
 	 */
 	public validate(iban: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -22,7 +22,7 @@ class StarkIsIBANConstraint implements ValidatorConstraintInterface {
 
 	/**
 	 * Default message displayed if the IBAN number is not valid
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid IBAN number";

--- a/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsIBANValidatorName } from "../../validators/is-iban";
 class StarkIsIBANConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a given IBAN number is valid
-	 * @param iban - The iban to validate
+	 * @param iban The iban to validate
 	 * @returns `true` if the iban is valid
 	 */
 	public validate(iban: string): boolean {

--- a/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsISINValidatorName } from "../../validators/is-isin";
 class StarkIsISINConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the given ISIN number is valid
-	 * @param isin - the isin number to validate
-	 * @returns boolean - true if the isin is valid
+	 * @param isin - The isin number to validate
+	 * @returns `true` if the isin is valid
 	 */
 	public validate(isin: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -22,8 +22,8 @@ class StarkIsISINConstraint implements ValidatorConstraintInterface {
 	}
 
 	/**
-	 * Displayes message if the ISIN number is not valid
-	 * @returns a default message
+	 * Default message displayed if the ISIN number is not valid
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid ISIN number";
@@ -32,7 +32,7 @@ class StarkIsISINConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsISIN validator constraint
- * @param validationOptions - will ensure if the isin is valid or not
+ * @param validationOptions - The options that will define the validity of the ISIN number
  * @returns Function
  */
 export function StarkIsISIN(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsISINValidatorName } from "../../validators/is-isin";
 class StarkIsISINConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the given ISIN number is valid
-	 * @param isin - The isin number to validate
+	 * @param isin The isin number to validate
 	 * @returns `true` if the isin is valid
 	 */
 	public validate(isin: string): boolean {
@@ -32,7 +32,7 @@ class StarkIsISINConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsISIN validator constraint
- * @param validationOptions - The options that will define the validity of the ISIN number
+ * @param validationOptions The options that will define the validity of the ISIN number
  * @returns Function
  */
 export function StarkIsISIN(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsKBOValidatorName } from "../../validators/is-kbo";
 class StarkIsKBOConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the given KBO number is valid
-	 * @param kbo - the kbo to validate
-	 * @returns boolean - true if the kbo has been validated
+	 * @param kbo - The kbo to validate
+	 * @returns `true` if the kbo has been validated
 	 */
 	public validate(kbo: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -23,7 +23,7 @@ class StarkIsKBOConstraint implements ValidatorConstraintInterface {
 
 	/**
 	 * Default message displayed if the KBO number is not valid
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "$property value is not a valid KBO number";
@@ -32,7 +32,7 @@ class StarkIsKBOConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsKBO validator constraint
- * @param validationOptions - the options that will define the validity of the kbo number
+ * @param validationOptions - The options that will define the validity of the kbo number
  * @returns Function
  */
 export function StarkIsKBO(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsKBOValidatorName } from "../../validators/is-kbo";
 class StarkIsKBOConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the given KBO number is valid
-	 * @param kbo - The kbo to validate
+	 * @param kbo The kbo to validate
 	 * @returns `true` if the kbo has been validated
 	 */
 	public validate(kbo: string): boolean {
@@ -32,7 +32,7 @@ class StarkIsKBOConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsKBO validator constraint
- * @param validationOptions - The options that will define the validity of the kbo number
+ * @param validationOptions The options that will define the validity of the kbo number
  * @returns Function
  */
 export function StarkIsKBO(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
@@ -40,7 +40,7 @@ class StarkIsNINConstraint implements ValidatorConstraintInterface {
 /**
  * Validator decorator that uses the StarkIsNIN validator constraint
  * @param property - The property to validate
- * @param validationOptions - the options that will define if the nin is valid
+ * @param validationOptions - The options that will define if the nin is valid
  */
 export function StarkIsNIN(property: string, validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
@@ -39,8 +39,8 @@ class StarkIsNINConstraint implements ValidatorConstraintInterface {
 
 /**
  * Validator decorator that uses the StarkIsNIN validator constraint
- * @param property - The property to validate
- * @param validationOptions - The options that will define if the nin is valid
+ * @param property The property to validate
+ * @param validationOptions The options that will define if the nin is valid
  */
 export function StarkIsNIN(property: string, validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
@@ -12,8 +12,8 @@ import { starkIsSupportedLanguageValidatorName } from "../../validators/is-suppo
 class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the language is supported
-	 * @param isoCode - the iseCode to validate
-	 * @returns boolean - true if the isoCode is valid
+	 * @param isoCode - The iseCode to validate
+	 * @returns `true` if the isoCode is valid
 	 */
 	public validate(isoCode: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
@@ -22,7 +22,7 @@ class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface
 
 	/**
 	 * Default message displayed if the language is not supported
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		return "The language ISO code '$value' is not supported by the Stark framework.";
@@ -31,7 +31,7 @@ class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface
 
 /**
  * Validator decorator that uses the StarkIsSupportedLanguage validator constraint
- * @param validationOptions - ensures that the language is supported or not
+ * @param validationOptions - The options that will define the validity of the language
  * @returns Function
  */
 export function StarkIsSupportedLanguage(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
@@ -12,7 +12,7 @@ import { starkIsSupportedLanguageValidatorName } from "../../validators/is-suppo
 class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that the language is supported
-	 * @param isoCode - The iseCode to validate
+	 * @param isoCode The iseCode to validate
 	 * @returns `true` if the isoCode is valid
 	 */
 	public validate(isoCode: string): boolean {
@@ -31,7 +31,7 @@ class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface
 
 /**
  * Validator decorator that uses the StarkIsSupportedLanguage validator constraint
- * @param validationOptions - The options that will define the validity of the language
+ * @param validationOptions The options that will define the validity of the language
  * @returns Function
  */
 export function StarkIsSupportedLanguage(validationOptions?: ValidationOptions): Function {

--- a/packages/stark-core/src/validation/decorators/map-is-valid/map-is-valid.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/map-is-valid/map-is-valid.validator.decorator.ts
@@ -31,7 +31,7 @@ class StarkMapIsValidConstraint implements ValidatorConstraintInterface {
 	/**
 	 * Validates that a give Map is valid
 	 * @param map: the map to validate
-	 * @returns boolean - true if the map is valid
+	 * @returns `true` if the map is valid
 	 */
 	public validate(map: Map<any, any>): boolean {
 		if (!(map instanceof Map) || !map.size) {
@@ -56,7 +56,7 @@ class StarkMapIsValidConstraint implements ValidatorConstraintInterface {
 
 	/**
 	 * Default message displayed when the map contains invalid entries
-	 * @returns a default message
+	 * @returns A default message
 	 */
 	public defaultMessage(): string {
 		let keysValidationMessage: string = StarkValidationErrorsUtil.toString(this.keysValidationErrors);

--- a/packages/stark-core/src/validation/validator.intf.ts
+++ b/packages/stark-core/src/validation/validator.intf.ts
@@ -6,9 +6,9 @@ import { Validator } from "class-validator";
 export interface StarkValidator extends Validator {
 	/**
 	 * Validates that the size of the given array is between the minimum and maximum limits defined
-	 * @param value - An array of selected items
-	 * @param minSize - The minSize we want to apply to the array
-	 * @param maxSize - The maxSize we want to apply to the array
+	 * @param value An array of selected items
+	 * @param minSize The minSize we want to apply to the array
+	 * @param maxSize The maxSize we want to apply to the array
 	 * @returns `true` if the array size range is valid
 	 */
 	starkArraySizeRange(value: any[], minSize: number, maxSize: number): boolean;
@@ -16,8 +16,8 @@ export interface StarkValidator extends Validator {
 	/**
 	 * Validates that the given string is a valid BBAN account. (Based on the country).
 	 * This validation requires a special usage because of the country code.
-	 * @param value - The bban account number to validate
-	 * @param countryCode - The country code that will be used to validate the bban number
+	 * @param value The bban account number to validate
+	 * @param countryCode The country code that will be used to validate the bban number
 	 * @returns `true` if the bban number is valid
 	 */
 	starkIsBBAN(value: string, countryCode: string): boolean;
@@ -45,28 +45,28 @@ export interface StarkValidator extends Validator {
 	 *
 	 * See {@link https://en.wikipedia.org/wiki/ISO_9362}
 	 *
-	 * @param value - The bic to validate
+	 * @param value The bic to validate
 	 * @returns `true` if the bic is valid
 	 */
 	starkIsBIC(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid company number (Belgium).
-	 * @param value - The company number to validate
+	 * @param value The company number to validate
 	 * @returns `true` if the company number if valid
 	 */
 	starkIsCompanyNumber(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid establishment unit number (Belgium).
-	 * @param value - The establishmentNumber to validate
+	 * @param value The establishmentNumber to validate
 	 * @returns `true` if the establishment number is valid
 	 */
 	starkIsEstablishmentUnitNumber(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid IBAN. (Based on the country)
-	 * @param value - The iban number to validate
+	 * @param value The iban number to validate
 	 * @returns `true` if the iban is valid
 	 */
 	starkIsIBAN(value: string): boolean;
@@ -79,14 +79,14 @@ export interface StarkValidator extends Validator {
 	 *
 	 * Checks if the number is a valid ISIN number (Modulus 10 Double Add Double)
 	 *
-	 * @param value - The isin number to validate
+	 * @param value The isin number to validate
 	 * @returns `true` if the iban is valid
 	 */
 	starkIsISIN(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid KBO number (Belgium).
-	 * @param value - The kbo number to validate
+	 * @param value The kbo number to validate
 	 * @returns `true` if the kbo number is valid
 	 */
 	starkIsKBO(value: string): boolean;
@@ -94,29 +94,29 @@ export interface StarkValidator extends Validator {
 	/**
 	 * Validates that the given string is a valid NIN (National Identifier Number).
 	 * This validation requires a special usage because of the of the country code.
-	 * @param value - The nin to validate
-	 * @param countryCode - The country code to use for the nin validation
+	 * @param value The nin to validate
+	 * @param countryCode The country code to use for the nin validation
 	 * @returns `true` if the nin is valid
 	 */
 	starkIsNIN(value: string, countryCode: string): boolean;
 
 	/**
 	 * Validates that the Map is not empty (it should have entries).
-	 * @param value - The map to validate
+	 * @param value The map to validate
 	 * @returns `true` if the map is not empty
 	 */
 	starkMapNotEmpty(value: Map<any, any>): boolean;
 
 	/**
 	 * Validates that the given StarkLanguage object is a supported language by Stark.
-	 * @param value - The StarkLanguage object to validate
+	 * @param value The StarkLanguage object to validate
 	 * @returns `true` if the object if valid
 	 */
 	starkIsSupportedLanguage(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid date.
-	 * @param value - The string to validate
+	 * @param value The string to validate
 	 * @returns `true` if the string is a valid date
 	 */
 	starkIsDateTime(value: string): boolean;

--- a/packages/stark-core/src/validation/validator.intf.ts
+++ b/packages/stark-core/src/validation/validator.intf.ts
@@ -6,19 +6,19 @@ import { Validator } from "class-validator";
 export interface StarkValidator extends Validator {
 	/**
 	 * Validates that the size of the given array is between the minimum and maximum limits defined
-	 * @param value - an array of selected items
-	 * @param minSize - the minSize we want to apply to the array
-	 * @param maxSize - the maxSize we want to apply to the array
-	 * @returns boolean - true if the array size range is valid
+	 * @param value - An array of selected items
+	 * @param minSize - The minSize we want to apply to the array
+	 * @param maxSize - The maxSize we want to apply to the array
+	 * @returns `true` if the array size range is valid
 	 */
 	starkArraySizeRange(value: any[], minSize: number, maxSize: number): boolean;
 
 	/**
 	 * Validates that the given string is a valid BBAN account. (Based on the country).
 	 * This validation requires a special usage because of the country code.
-	 * @param value - the bban account number to validate
-	 * @param countryCode - the country code that will be used to validate the bban number
-	 * @returns boolean - true if the bban number is valid
+	 * @param value - The bban account number to validate
+	 * @param countryCode - The country code that will be used to validate the bban number
+	 * @returns `true` if the bban number is valid
 	 */
 	starkIsBBAN(value: string, countryCode: string): boolean;
 
@@ -43,31 +43,31 @@ export interface StarkValidator extends Validator {
 	 * <li>3 letters or digits: branch code, optional ('XXX' for primary office)</li>
 	 * </ul>
 	 *
-	 * <a href="http://en.wikipedia.org/wiki/ISO_9362">http://en.wikipedia.org/wiki/ISO_9362</a>
+	 * @link https://en.wikipedia.org/wiki/ISO_9362
 	 *
-	 * @param value - the bic to validate
-	 * @returns boolean - true if the bic is valid
+	 * @param value - The bic to validate
+	 * @returns `true` if the bic is valid
 	 */
 	starkIsBIC(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid company number (Belgium).
-	 * @param value - the company number to validate
-	 * @returns boolean - true if the company number if valid
+	 * @param value - The company number to validate
+	 * @returns `true` if the company number if valid
 	 */
 	starkIsCompanyNumber(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid establishment unit number (Belgium).
-	 * @param value - the establishmentNumber to validate
-	 * @returns boolean - true if the establishment number is valid
+	 * @param value - The establishmentNumber to validate
+	 * @returns `true` if the establishment number is valid
 	 */
 	starkIsEstablishmentUnitNumber(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid IBAN. (Based on the country)
-	 * @param value - the iban number to validate
-	 * @returns boolean - true if the iban is valid
+	 * @param value - The iban number to validate
+	 * @returns `true` if the iban is valid
 	 */
 	starkIsIBAN(value: string): boolean;
 
@@ -79,45 +79,45 @@ export interface StarkValidator extends Validator {
 	 *
 	 * Checks if the number is a valid ISIN number (Modulus 10 Double Add Double)
 	 *
-	 * @param value - the isin number to validate
-	 * @returns boolean - true if the iban is valid
+	 * @param value - The isin number to validate
+	 * @returns `true` if the iban is valid
 	 */
 	starkIsISIN(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid KBO number (Belgium).
-	 * @param value - the kbo number to validate
-	 * @returns boolean - true if the kbo number is valid
+	 * @param value - The kbo number to validate
+	 * @returns `true` if the kbo number is valid
 	 */
 	starkIsKBO(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid NIN (National Identifier Number).
 	 * This validation requires a special usage because of the of the country code.
-	 * @param value - the nin to validate
-	 * @param countryCode - the country code to use for the nin validation
-	 * @returns boolean - true if the nin is valid
+	 * @param value - The nin to validate
+	 * @param countryCode - The country code to use for the nin validation
+	 * @returns `true` if the nin is valid
 	 */
 	starkIsNIN(value: string, countryCode: string): boolean;
 
 	/**
 	 * Validates that the Map is not empty (it should have entries).
-	 * @param value - the map to validate
-	 * @returns boolean - true if the map is not empty
+	 * @param value - The map to validate
+	 * @returns `true` if the map is not empty
 	 */
 	starkMapNotEmpty(value: Map<any, any>): boolean;
 
 	/**
 	 * Validates that the given StarkLanguage object is a supported language by Stark.
-	 * @param value - the StarkLanguage object to validate
-	 * @returns boolean - true if the object if valid
+	 * @param value - The StarkLanguage object to validate
+	 * @returns `true` if the object if valid
 	 */
 	starkIsSupportedLanguage(value: string): boolean;
 
 	/**
 	 * Validates that the given string is a valid date.
-	 * @param value - the string to validate
-	 * @returns boolean - true if the string is a valid date
+	 * @param value - The string to validate
+	 * @returns `true` if the string is a valid date
 	 */
 	starkIsDateTime(value: string): boolean;
 }

--- a/packages/stark-core/src/validation/validator.intf.ts
+++ b/packages/stark-core/src/validation/validator.intf.ts
@@ -43,7 +43,7 @@ export interface StarkValidator extends Validator {
 	 * <li>3 letters or digits: branch code, optional ('XXX' for primary office)</li>
 	 * </ul>
 	 *
-	 * @link https://en.wikipedia.org/wiki/ISO_9362
+	 * See {@link https://en.wikipedia.org/wiki/ISO_9362}
 	 *
 	 * @param value - The bic to validate
 	 * @returns `true` if the bic is valid

--- a/packages/stark-core/src/validation/validators/array-size-range/array-size-range.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/array-size-range/array-size-range.validator.fn.ts
@@ -9,10 +9,10 @@ export const starkArraySizeRangeValidatorName = "starkArraySizeRange";
 /**
  * @ignore
  * Validates that the size of the given array is between the minimum and maximum limits defined
- * @param array - an array of selected items
- * @param minSize - the minSize we want to apply to the array
- * @param maxSize - the maxSize we want to apply to the array
- * @returns boolean - true if the array size range is valid
+ * @param array - An array of selected items
+ * @param minSize - The minSize we want to apply to the array
+ * @param maxSize - The maxSize we want to apply to the array
+ * @returns `true` if the array size range is valid
  */
 export function starkArraySizeRange(array: any[], minSize?: number, maxSize?: number): boolean {
 	// by default, if the requested validator class is not already registered in the container from the 'class-validator' container

--- a/packages/stark-core/src/validation/validators/array-size-range/array-size-range.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/array-size-range/array-size-range.validator.fn.ts
@@ -9,9 +9,9 @@ export const starkArraySizeRangeValidatorName = "starkArraySizeRange";
 /**
  * @ignore
  * Validates that the size of the given array is between the minimum and maximum limits defined
- * @param array - An array of selected items
- * @param minSize - The minSize we want to apply to the array
- * @param maxSize - The maxSize we want to apply to the array
+ * @param array An array of selected items
+ * @param minSize The minSize we want to apply to the array
+ * @param maxSize The maxSize we want to apply to the array
  * @returns `true` if the array size range is valid
  */
 export function starkArraySizeRange(array: any[], minSize?: number, maxSize?: number): boolean {

--- a/packages/stark-core/src/validation/validators/is-bban/is-bban.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-bban/is-bban.validator.fn.ts
@@ -12,9 +12,9 @@ export const starkIsBBANValidatorName = "starkIsBBAN";
  * @ignore
  * Validates that the given string is a valid BBAN account. (Based on the country).
  * This validation requires a special usage because of the country code.
- * @param bban - the bban account number to validate
- * @param countryCode - the country code that will be used to validate the bban number
- * @returns boolean - true if the bban number is valid
+ * @param bban - The bban account number to validate
+ * @param countryCode - The country code that will be used to validate the bban number
+ * @returns `true` if the bban number is valid
  */
 export function starkIsBBAN(bban: string, countryCode: string = ""): boolean {
 	const strippedBban: string = typeof bban === "string" ? bban.replace(/\s/g, "") : bban;
@@ -34,8 +34,8 @@ export function starkIsBBAN(bban: string, countryCode: string = ""): boolean {
 /**
  * @ignore
  * Calculates the check digit, to ensure there is no error with the bban number
- * @param bbanNumber - the bban number to validate
- * @returns the newly calculated check digits
+ * @param bbanNumber - The bban number to validate
+ * @returns The newly calculated check digits
  */
 function calculateCheckDigit(bbanNumber: string): number {
 	const firstPart: number = parseInt(bbanNumber.substring(0, bbanNumber.length - 2), 10);

--- a/packages/stark-core/src/validation/validators/is-bban/is-bban.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-bban/is-bban.validator.fn.ts
@@ -12,8 +12,8 @@ export const starkIsBBANValidatorName = "starkIsBBAN";
  * @ignore
  * Validates that the given string is a valid BBAN account. (Based on the country).
  * This validation requires a special usage because of the country code.
- * @param bban - The bban account number to validate
- * @param countryCode - The country code that will be used to validate the bban number
+ * @param bban The bban account number to validate
+ * @param countryCode The country code that will be used to validate the bban number
  * @returns `true` if the bban number is valid
  */
 export function starkIsBBAN(bban: string, countryCode: string = ""): boolean {
@@ -34,7 +34,7 @@ export function starkIsBBAN(bban: string, countryCode: string = ""): boolean {
 /**
  * @ignore
  * Calculates the check digit, to ensure there is no error with the bban number
- * @param bbanNumber - The bban number to validate
+ * @param bbanNumber The bban number to validate
  * @returns The newly calculated check digits
  */
 function calculateCheckDigit(bbanNumber: string): number {

--- a/packages/stark-core/src/validation/validators/is-bic/is-bic.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-bic/is-bic.validator.fn.ts
@@ -26,7 +26,7 @@ export const starkIsBICValidatorName = "starkIsBIC";
  * <li>3 letters or digits: branch code, optional ('XXX' for primary office)</li>
  * </ul>
  *
- * <a href="http://en.wikipedia.org/wiki/ISO_9362">http://en.wikipedia.org/wiki/ISO_9362</a>
+ * @link https://en.wikipedia.org/wiki/ISO_9362
  */
 export function starkIsBIC(bic: string): boolean {
 	const swiftRegex: RegExp = /^[A-Za-z]{6}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?$/;

--- a/packages/stark-core/src/validation/validators/is-bic/is-bic.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-bic/is-bic.validator.fn.ts
@@ -26,7 +26,7 @@ export const starkIsBICValidatorName = "starkIsBIC";
  * <li>3 letters or digits: branch code, optional ('XXX' for primary office)</li>
  * </ul>
  *
- * @link https://en.wikipedia.org/wiki/ISO_9362
+ * See {@link https://en.wikipedia.org/wiki/ISO_9362}
  */
 export function starkIsBIC(bic: string): boolean {
 	const swiftRegex: RegExp = /^[A-Za-z]{6}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?$/;

--- a/packages/stark-core/src/validation/validators/is-company-number/is-company-number.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-company-number/is-company-number.validator.fn.ts
@@ -7,7 +7,7 @@ export const starkIsCompanyNumberValidatorName = "starkIsCompanyNumber";
 /**
  * @ignore
  * Validates that the given string is a valid company number (Belgium).
- * @param companyNumber - the company number to validate
+ * @param companyNumber - The company number to validate
  */
 export function starkIsCompanyNumber(companyNumber: string): boolean {
 	let valid = false;

--- a/packages/stark-core/src/validation/validators/is-company-number/is-company-number.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-company-number/is-company-number.validator.fn.ts
@@ -7,7 +7,7 @@ export const starkIsCompanyNumberValidatorName = "starkIsCompanyNumber";
 /**
  * @ignore
  * Validates that the given string is a valid company number (Belgium).
- * @param companyNumber - The company number to validate
+ * @param companyNumber The company number to validate
  */
 export function starkIsCompanyNumber(companyNumber: string): boolean {
 	let valid = false;

--- a/packages/stark-core/src/validation/validators/is-date-time/is-date-time.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-date-time/is-date-time.validator.fn.ts
@@ -9,8 +9,8 @@ export const starkIsDateTimeValidatorName = "starkIsDateTime";
 /**
  * @ignore
  * Validates that the given string is a valid date.
- * @param inputString - the date and time to validate
- * @param format - the date format used to validate the entered date
+ * @param inputString - The date and time to validate
+ * @param format - The date format used to validate the entered date
  */
 export function starkIsDateTime(inputString: string, format: string = "DD-MM-YYYY HH:mm:ss"): boolean {
 	return moment(inputString, format, true).isValid();

--- a/packages/stark-core/src/validation/validators/is-date-time/is-date-time.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-date-time/is-date-time.validator.fn.ts
@@ -9,8 +9,8 @@ export const starkIsDateTimeValidatorName = "starkIsDateTime";
 /**
  * @ignore
  * Validates that the given string is a valid date.
- * @param inputString - The date and time to validate
- * @param format - The date format used to validate the entered date
+ * @param inputString The date and time to validate
+ * @param format The date format used to validate the entered date
  */
 export function starkIsDateTime(inputString: string, format: string = "DD-MM-YYYY HH:mm:ss"): boolean {
 	return moment(inputString, format, true).isValid();

--- a/packages/stark-core/src/validation/validators/is-establishment-unit-number/is-establishment-unit-number.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-establishment-unit-number/is-establishment-unit-number.validator.fn.ts
@@ -9,7 +9,7 @@ export const starkIsEstablishmentUnitNumberValidatorName = "starkIsEstablishment
 /**
  * @ignore
  * Validates that the given string is a valid establishment unit number (Belgium).
- * @param establishmentNumber - the establishmentNumber to validate
+ * @param establishmentNumber - The establishmentNumber to validate
  */
 export function starkIsEstablishmentUnitNumber(establishmentNumber: string): boolean {
 	const controlNumberBeginIndex = 8;

--- a/packages/stark-core/src/validation/validators/is-establishment-unit-number/is-establishment-unit-number.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-establishment-unit-number/is-establishment-unit-number.validator.fn.ts
@@ -9,7 +9,7 @@ export const starkIsEstablishmentUnitNumberValidatorName = "starkIsEstablishment
 /**
  * @ignore
  * Validates that the given string is a valid establishment unit number (Belgium).
- * @param establishmentNumber - The establishmentNumber to validate
+ * @param establishmentNumber The establishmentNumber to validate
  */
 export function starkIsEstablishmentUnitNumber(establishmentNumber: string): boolean {
 	const controlNumberBeginIndex = 8;

--- a/packages/stark-core/src/validation/validators/is-iban/is-iban.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-iban/is-iban.validator.fn.ts
@@ -9,7 +9,7 @@ export const starkIsIBANValidatorName = "starkIsIBAN";
 /**
  * @ignore
  * Validates that the given string is a valid IBAN. (Based on the country)
- * @param iban - the IBAN number to validate
+ * @param iban - The IBAN number to validate
  */
 export function starkIsIBAN(iban: string): boolean {
 	if (typeof iban === "string") {

--- a/packages/stark-core/src/validation/validators/is-iban/is-iban.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-iban/is-iban.validator.fn.ts
@@ -9,7 +9,7 @@ export const starkIsIBANValidatorName = "starkIsIBAN";
 /**
  * @ignore
  * Validates that the given string is a valid IBAN. (Based on the country)
- * @param iban - The IBAN number to validate
+ * @param iban The IBAN number to validate
  */
 export function starkIsIBAN(iban: string): boolean {
 	if (typeof iban === "string") {

--- a/packages/stark-core/src/validation/validators/is-kbo/is-kbo.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-kbo/is-kbo.validator.fn.ts
@@ -10,8 +10,8 @@ export const starkIsKBOValidatorName = "starkIsKBO";
 /**
  * @ignore
  * Validates that the given string is a valid KBO number (Belgium).
- * @param kbo - the kbo to validate
- * @returns boolean - true if the kbo is valid
+ * @param kbo - The kbo to validate
+ * @returns `true` if the kbo is valid
  */
 export function starkIsKBO(kbo: string): boolean {
 	return starkIsCompanyNumber(kbo) || starkIsEstablishmentUnitNumber(kbo);

--- a/packages/stark-core/src/validation/validators/is-kbo/is-kbo.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-kbo/is-kbo.validator.fn.ts
@@ -10,7 +10,7 @@ export const starkIsKBOValidatorName = "starkIsKBO";
 /**
  * @ignore
  * Validates that the given string is a valid KBO number (Belgium).
- * @param kbo - The kbo to validate
+ * @param kbo The kbo to validate
  * @returns `true` if the kbo is valid
  */
 export function starkIsKBO(kbo: string): boolean {

--- a/packages/stark-core/src/validation/validators/is-nin/is-nin.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-nin/is-nin.validator.fn.ts
@@ -9,9 +9,9 @@ export const starkIsNINValidatorName = "starkIsNIN";
 /**
  * @ignore
  * Validator function that checks if the given input is a valid national identification number (NIN)
- * @param nin - the NIN to check
- * @param countryCode - the country code
- * @returns boolean - true if the given input is a valid NIN
+ * @param nin - The NIN to check
+ * @param countryCode - The country code
+ * @returns `true` if the given input is a valid NIN
  */
 export function starkIsNIN(nin: string, countryCode: string): boolean {
 	let isValid = false;

--- a/packages/stark-core/src/validation/validators/is-nin/is-nin.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-nin/is-nin.validator.fn.ts
@@ -9,8 +9,8 @@ export const starkIsNINValidatorName = "starkIsNIN";
 /**
  * @ignore
  * Validator function that checks if the given input is a valid national identification number (NIN)
- * @param nin - The NIN to check
- * @param countryCode - The country code
+ * @param nin The NIN to check
+ * @param countryCode The country code
  * @returns `true` if the given input is a valid NIN
  */
 export function starkIsNIN(nin: string, countryCode: string): boolean {

--- a/packages/stark-core/src/validation/validators/is-supported-language/is-supported-language.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-supported-language/is-supported-language.fn.ts
@@ -10,8 +10,8 @@ export const starkIsSupportedLanguageValidatorName = "starkIsSupportedLanguage";
 /**
  * @ignore
  * Validator function that checks if the given ISO code is supported by Stark or not
- * @param isoCode - the ISO code to check
- * @returns true if the given ISO code is part of {@link StarkLanguage}
+ * @param isoCode - The ISO code to check
+ * @returns `true` if the given ISO code is part of {@link StarkLanguage}
  */
 export function starkIsSupportedLanguage(isoCode: string): boolean {
 	if (typeof isoCode === "string") {

--- a/packages/stark-core/src/validation/validators/is-supported-language/is-supported-language.fn.ts
+++ b/packages/stark-core/src/validation/validators/is-supported-language/is-supported-language.fn.ts
@@ -10,7 +10,7 @@ export const starkIsSupportedLanguageValidatorName = "starkIsSupportedLanguage";
 /**
  * @ignore
  * Validator function that checks if the given ISO code is supported by Stark or not
- * @param isoCode - The ISO code to check
+ * @param isoCode The ISO code to check
  * @returns `true` if the given ISO code is part of {@link StarkLanguage}
  */
 export function starkIsSupportedLanguage(isoCode: string): boolean {

--- a/packages/stark-core/src/validation/validators/map-not-empty/map-not-empty.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/map-not-empty/map-not-empty.validator.fn.ts
@@ -5,8 +5,8 @@ export const starkMapNotEmptyValidatorName = "starkMapNotEmpty";
 
 /**
  * Validator function that checks if the given map is not empty
- * @param map the map to check
- * @returns true if the map is not empty
+ * @param map - The map to check
+ * @returns `true` if the map is not empty
  */
 export function starkMapNotEmpty(map: Map<any, any>): boolean {
 	return map instanceof Map && map.size > 0;

--- a/packages/stark-core/src/validation/validators/map-not-empty/map-not-empty.validator.fn.ts
+++ b/packages/stark-core/src/validation/validators/map-not-empty/map-not-empty.validator.fn.ts
@@ -5,7 +5,7 @@ export const starkMapNotEmptyValidatorName = "starkMapNotEmpty";
 
 /**
  * Validator function that checks if the given map is not empty
- * @param map - The map to check
+ * @param map The map to check
  * @returns `true` if the map is not empty
  */
 export function starkMapNotEmpty(map: Map<any, any>): boolean {

--- a/packages/stark-core/testing/README.md
+++ b/packages/stark-core/testing/README.md
@@ -1,0 +1,3 @@
+# Stark Core Testing subpackage
+
+See [Stark Core - Testing subpackage](../../../docs/stark-core/TESTING_SUBPACKAGE.md)

--- a/packages/stark-core/testing/src/http.mock.ts
+++ b/packages/stark-core/testing/src/http.mock.ts
@@ -1,16 +1,15 @@
 import { StarkHttpService, StarkResource } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpy = jasmine.createSpy;
 import createSpyObj = jasmine.createSpyObj;
 
 /**
- * Mock class of the StarkHttpService interface.
- * @link StarkHttpService
+ * Mock class of the {@link StarkHttpService} interface.
  */
 export class MockStarkHttpService<T extends StarkResource> implements SpyObj<StarkHttpService<T>> {
 	/**
-	 * Gets the core Angular HTTP API (HttpClient)
-	 * @returns Angular Http client
+	 * See [StarkHttpService rawHttpClient]{@link StarkHttpService#rawHttpClient} property
 	 */
 	public readonly rawHttpClient: SpyObj<StarkHttpService<T>["rawHttpClient"]> = createSpyObj<StarkHttpService<T>["rawHttpClient"]>(
 		"rawHttpClient",
@@ -18,16 +17,12 @@ export class MockStarkHttpService<T extends StarkResource> implements SpyObj<Sta
 	);
 
 	/**
-	 * Executes requests to fetch a single resource
-	 * @param request - The HTTP request to be executed
-	 * @returns Observable that will emit the single item response wrapper
+	 * See [StarkHttpService executeSingleItemRequest]{@link StarkHttpService#executeSingleItemRequest} method
 	 */
-	public executeSingleItemRequest: SpyObj<StarkHttpService<T>>["executeSingleItemRequest"] = createSpy("executeSingleItemRequest");
+	public executeSingleItemRequest: Spy<StarkHttpService<T>["executeSingleItemRequest"]> = createSpy("executeSingleItemRequest");
 
 	/**
-	 * Executes requests to fetch an array of resources
-	 * @param request - The HTTP request to be executed
-	 * @returns Observable that will emit the collection response wrapper
+	 * See [StarkHttpService executeCollectionRequest]{@link StarkHttpService#executeCollectionRequest} method
 	 */
-	public executeCollectionRequest: SpyObj<StarkHttpService<T>>["executeCollectionRequest"] = createSpy("executeCollectionRequest");
+	public executeCollectionRequest: Spy<StarkHttpService<T>["executeCollectionRequest"]> = createSpy("executeCollectionRequest");
 }

--- a/packages/stark-core/testing/src/logging.mock.ts
+++ b/packages/stark-core/testing/src/logging.mock.ts
@@ -1,56 +1,57 @@
 import { StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpy = jasmine.createSpy;
 
 /**
- * Mock class of the StarkLoggingService interface.
- * @link StarkLoggingService
+ * Mock class of the {@link StarkLoggingService} interface.
  */
 export class MockStarkLoggingService implements SpyObj<StarkLoggingService> {
 	/**
-	 * Gets the current correlationId. In fact when the logging service is created, it gets a unique correlation Id.
-	 * This value can be used while displaying a generic error message.
+	 * See [StarkLoggingService correlationId]{@link StarkLoggingService#correlationId} property
 	 */
 	public correlationId: StarkLoggingService["correlationId"];
+
+	/**
+	 * See [StarkLoggingService correlationIdHttpHeaderName]{@link StarkLoggingService#correlationIdHttpHeaderName} property
+	 */
 	public correlationIdHttpHeaderName: StarkLoggingService["correlationIdHttpHeaderName"];
 
 	/**
-	 * Logs debug messages to be used only in development to track issues.
-	 * The debug messages are only logged (and afterwards stored in the Redux store) only when the debugLoggingEnabled configuration setting from the StarkApplicationConfig is set to true.
-	 * @param args - the arguments to log
+	 * See [StarkLoggingService generateNewCorrelationId]{@link StarkLoggingService#generateNewCorrelationId} method
 	 */
-	public debug: SpyObj<StarkLoggingService>["debug"] = createSpy("debug");
+	public generateNewCorrelationId: Spy<StarkLoggingService["generateNewCorrelationId"]> = createSpy("generateNewCorrelationId");
 
 	/**
-	 * Logs information messages. These messages are also stored in the Redux store.
-	 * @param args - the arguments to log
+	 * See [StarkLoggingService debug]{@link StarkLoggingService#debug} method
 	 */
-	public info: SpyObj<StarkLoggingService>["info"] = createSpy("info");
+	public debug: Spy<StarkLoggingService["debug"]> = createSpy("debug");
 
 	/**
-	 * Logs warning messages. Warning messages can, for instance, indicate a non blocking problem in the software. These messages are also stored in the Redux store.
-	 * @param args - the arguments to log
+	 * See [StarkLoggingService info]{@link StarkLoggingService#info} method
 	 */
-	public warn: SpyObj<StarkLoggingService>["warn"] = createSpy("warn");
+	public info: Spy<StarkLoggingService["info"]> = createSpy("info");
 
 	/**
-	 * Logs error messages. Error messages should be logged when there was an unexpected error while executing the code.
-	 * They are typically logged in the catch method of a try-catch block. These messages are also stored in the Redux store.
-	 * @param message - the message to log
-	 * @param error - the arguments to log
+	 * See [StarkLoggingService warn]{@link StarkLoggingService#warn} method
 	 */
-	public error: SpyObj<StarkLoggingService>["error"] = createSpy("error");
+	public warn: Spy<StarkLoggingService["warn"]> = createSpy("warn");
 
 	/**
-	 * Method to generate a new correlationId.
+	 * See [StarkLoggingService error]{@link StarkLoggingService#error} method
 	 */
-	public generateNewCorrelationId: SpyObj<StarkLoggingService>["generateNewCorrelationId"] = createSpy("generateNewCorrelationId");
+	public error: Spy<StarkLoggingService["error"]> = createSpy("error");
 
+	/**
+	 * Creates a new mock instance.
+	 * @param mockCorrelationId - Correlation id to set to this instance
+	 * @param mockCorrelationIdHeaderName - Correlation header name to set to this instance
+	 */
 	public constructor(
-		correlationId: string = "dummyCorrelationId",
+		mockCorrelationId: string = "dummyCorrelationId",
 		mockCorrelationIdHeaderName: string = "Correlation-Id-HttpHeaderName"
 	) {
-		this.correlationId = correlationId;
+		this.correlationId = mockCorrelationId;
 		this.correlationIdHttpHeaderName = mockCorrelationIdHeaderName;
 	}
 }

--- a/packages/stark-core/testing/src/logging.mock.ts
+++ b/packages/stark-core/testing/src/logging.mock.ts
@@ -44,8 +44,8 @@ export class MockStarkLoggingService implements SpyObj<StarkLoggingService> {
 
 	/**
 	 * Creates a new mock instance.
-	 * @param mockCorrelationId - Correlation id to set to this instance
-	 * @param mockCorrelationIdHeaderName - Correlation header name to set to this instance
+	 * @param mockCorrelationId Correlation id to set to this instance
+	 * @param mockCorrelationIdHeaderName Correlation header name to set to this instance
 	 */
 	public constructor(
 		mockCorrelationId: string = "dummyCorrelationId",

--- a/packages/stark-core/testing/src/routing.mock.ts
+++ b/packages/stark-core/testing/src/routing.mock.ts
@@ -1,32 +1,108 @@
 import { StarkRoutingService } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpy = jasmine.createSpy;
 
 /**
- * @ignore
+ * Mock class of the {@link StarkRoutingService} interface.
  */
 export class MockStarkRoutingService implements SpyObj<StarkRoutingService> {
-	public navigateTo: SpyObj<StarkRoutingService>["navigateTo"] = createSpy("navigateTo");
-	public navigateToHome: SpyObj<StarkRoutingService>["navigateToHome"] = createSpy("navigateToHome");
-	public navigateToPrevious: SpyObj<StarkRoutingService>["navigateToPrevious"] = createSpy("navigateToPrevious");
-	public reload: SpyObj<StarkRoutingService>["reload"] = createSpy("reload");
-	public getCurrentStateName: SpyObj<StarkRoutingService>["getCurrentStateName"] = createSpy("getCurrentStateName");
-	public getCurrentState: SpyObj<StarkRoutingService>["getCurrentState"] = createSpy("getCurrentState");
-	public getCurrentStateConfig: SpyObj<StarkRoutingService>["getCurrentStateConfig"] = createSpy("getCurrentStateConfig");
-	public getStatesConfig: SpyObj<StarkRoutingService>["getStatesConfig"] = createSpy("getStatesConfig");
-	public getStateConfigByUrlPath: SpyObj<StarkRoutingService>["getStateConfigByUrlPath"] = createSpy("getStateConfigByUrlPath");
-	public getStateDeclarationByStateName: SpyObj<StarkRoutingService>["getStateDeclarationByStateName"] = createSpy(
+	/**
+	 * See [StarkRoutingService navigateTo]{@link StarkRoutingService#navigateTo} method
+	 */
+	public navigateTo: Spy<StarkRoutingService["navigateTo"]> = createSpy("navigateTo");
+
+	/**
+	 * See [StarkRoutingService navigateToHome]{@link StarkRoutingService#navigateToHome} method
+	 */
+	public navigateToHome: Spy<StarkRoutingService["navigateToHome"]> = createSpy("navigateToHome");
+
+	/**
+	 * See [StarkRoutingService navigateToPrevious]{@link StarkRoutingService#navigateToPrevious} method
+	 */
+	public navigateToPrevious: Spy<StarkRoutingService["navigateToPrevious"]> = createSpy("navigateToPrevious");
+
+	/**
+	 * See [StarkRoutingService reload]{@link StarkRoutingService#reload} method
+	 */
+	public reload: Spy<StarkRoutingService["reload"]> = createSpy("reload");
+
+	/**
+	 * See [StarkRoutingService getCurrentStateName]{@link StarkRoutingService#getCurrentStateName} method
+	 */
+	public getCurrentStateName: Spy<StarkRoutingService["getCurrentStateName"]> = createSpy("getCurrentStateName");
+
+	/**
+	 * See [StarkRoutingService getCurrentState]{@link StarkRoutingService#getCurrentState} method
+	 */
+	public getCurrentState: Spy<StarkRoutingService["getCurrentState"]> = createSpy("getCurrentState");
+
+	/**
+	 * See [StarkRoutingService getCurrentStateConfig]{@link StarkRoutingService#getCurrentStateConfig} method
+	 */
+	public getCurrentStateConfig: Spy<StarkRoutingService["getCurrentStateConfig"]> = createSpy("getCurrentStateConfig");
+
+	/**
+	 * See [StarkRoutingService getStatesConfig]{@link StarkRoutingService#getStatesConfig} method
+	 */
+	public getStatesConfig: Spy<StarkRoutingService["getStatesConfig"]> = createSpy("getStatesConfig");
+
+	/**
+	 * See [StarkRoutingService getStateConfigByUrlPath]{@link StarkRoutingService#getStateConfigByUrlPath} method
+	 */
+	public getStateConfigByUrlPath: Spy<StarkRoutingService["getStateConfigByUrlPath"]> = createSpy("getStateConfigByUrlPath");
+
+	/**
+	 * See [StarkRoutingService getStateDeclarationByStateName]{@link StarkRoutingService#getStateDeclarationByStateName} method
+	 */
+	public getStateDeclarationByStateName: Spy<StarkRoutingService["getStateDeclarationByStateName"]> = createSpy(
 		"getStateDeclarationByStateName"
 	);
-	public getCurrentStateParams: SpyObj<StarkRoutingService>["getCurrentStateParams"] = createSpy("getCurrentStateParams");
-	public getStateTreeParams: SpyObj<StarkRoutingService>["getStateTreeParams"] = createSpy("getStateTreeParams");
-	public getStateTreeResolves: SpyObj<StarkRoutingService>["getStateTreeResolves"] = createSpy("getStateTreeResolves");
-	public getStateTreeData: SpyObj<StarkRoutingService>["getStateTreeData"] = createSpy("getStateTreeData");
-	public isCurrentUiState: SpyObj<StarkRoutingService>["isCurrentUiState"] = createSpy("isCurrentUiState");
-	public isCurrentUiStateIncludedIn: SpyObj<StarkRoutingService>["isCurrentUiStateIncludedIn"] = createSpy("includesState");
-	public addKnownNavigationRejectionCause: SpyObj<StarkRoutingService>["addKnownNavigationRejectionCause"] = createSpy(
+
+	/**
+	 * See [StarkRoutingService getCurrentStateParams]{@link StarkRoutingService#getCurrentStateParams} method
+	 */
+	public getCurrentStateParams: Spy<StarkRoutingService["getCurrentStateParams"]> = createSpy("getCurrentStateParams");
+
+	/**
+	 * See [StarkRoutingService getStateTreeParams]{@link StarkRoutingService#getStateTreeParams} method
+	 */
+	public getStateTreeParams: Spy<StarkRoutingService["getStateTreeParams"]> = createSpy("getStateTreeParams");
+
+	/**
+	 * See [StarkRoutingService getStateTreeResolves]{@link StarkRoutingService#getStateTreeResolves} method
+	 */
+	public getStateTreeResolves: Spy<StarkRoutingService["getStateTreeResolves"]> = createSpy("getStateTreeResolves");
+
+	/**
+	 * See [StarkRoutingService getStateTreeData]{@link StarkRoutingService#getStateTreeData} method
+	 */
+	public getStateTreeData: Spy<StarkRoutingService["getStateTreeData"]> = createSpy("getStateTreeData");
+
+	/**
+	 * See [StarkRoutingService isCurrentUiState]{@link StarkRoutingService#isCurrentUiState} method
+	 */
+	public isCurrentUiState: Spy<StarkRoutingService["isCurrentUiState"]> = createSpy("isCurrentUiState");
+
+	/**
+	 * See [StarkRoutingService isCurrentUiStateIncludedIn]{@link StarkRoutingService#isCurrentUiStateIncludedIn} method
+	 */
+	public isCurrentUiStateIncludedIn: Spy<StarkRoutingService["isCurrentUiStateIncludedIn"]> = createSpy("includesState");
+
+	/**
+	 * See [StarkRoutingService addKnownNavigationRejectionCause]{@link StarkRoutingService#addKnownNavigationRejectionCause} method
+	 */
+	public addKnownNavigationRejectionCause: Spy<StarkRoutingService["addKnownNavigationRejectionCause"]> = createSpy(
 		"addKnownNavigationRejectionCause"
 	);
-	public addTransitionHook: SpyObj<StarkRoutingService>["addTransitionHook"] = createSpy("addTransitionHook");
-	public getTranslationKeyFromState: SpyObj<StarkRoutingService>["getTranslationKeyFromState"] = createSpy("getTranslationKeyFromState");
+
+	/**
+	 * See [StarkRoutingService addTransitionHook]{@link StarkRoutingService#addTransitionHook} method
+	 */
+	public addTransitionHook: Spy<StarkRoutingService["addTransitionHook"]> = createSpy("addTransitionHook");
+
+	/**
+	 * See [StarkRoutingService getTranslationKeyFromState]{@link StarkRoutingService#getTranslationKeyFromState} method
+	 */
+	public getTranslationKeyFromState: Spy<StarkRoutingService["getTranslationKeyFromState"]> = createSpy("getTranslationKeyFromState");
 }

--- a/packages/stark-core/testing/src/session.mock.ts
+++ b/packages/stark-core/testing/src/session.mock.ts
@@ -1,25 +1,62 @@
 import { StarkSessionService } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpy = jasmine.createSpy;
 
 /**
- * @ignore
+ * Mock class of the {@link StarkSessionService} interface.
  */
 export class MockStarkSessionService implements SpyObj<StarkSessionService> {
-	public devAuthenticationHeaders: SpyObj<StarkSessionService>["devAuthenticationHeaders"];
+	/**
+	 * See [StarkSessionService devAuthenticationHeaders]{@link StarkSessionService#devAuthenticationHeaders} property
+	 */
+	public devAuthenticationHeaders: StarkSessionService["devAuthenticationHeaders"];
 
-	public getCurrentUser: SpyObj<StarkSessionService>["getCurrentUser"] = createSpy("getCurrentLanguage");
-	public getCurrentLanguage: SpyObj<StarkSessionService>["getCurrentLanguage"] = createSpy("getCurrentLanguage");
-	public setCurrentLanguage: SpyObj<StarkSessionService>["setCurrentLanguage"] = createSpy("setCurrentLanguage");
-	public login: SpyObj<StarkSessionService>["login"] = createSpy("login");
-	public logout: SpyObj<StarkSessionService>["logout"] = createSpy("logout");
-	public pauseUserActivityTracking: SpyObj<StarkSessionService>["pauseUserActivityTracking"] = createSpy("pauseUserActivityTracking");
-	public resumeUserActivityTracking: SpyObj<StarkSessionService>["resumeUserActivityTracking"] = createSpy("resumeUserActivityTracking");
-	public setDevAuthenticationHeaders: SpyObj<StarkSessionService>["setDevAuthenticationHeaders"] = createSpy(
-		"setDevAuthenticationHeaders"
-	);
+	/**
+	 * See [StarkSessionService getCurrentUser]{@link StarkSessionService#getCurrentUser} method
+	 */
+	public getCurrentUser: Spy<StarkSessionService["getCurrentUser"]> = createSpy("getCurrentUser");
 
-	public constructor(devAuthenticationHeaders?: Map<string, string>) {
+	/**
+	 * See [StarkSessionService getCurrentLanguage]{@link StarkSessionService#getCurrentLanguage} method
+	 */
+	public getCurrentLanguage: Spy<StarkSessionService["getCurrentLanguage"]> = createSpy("getCurrentLanguage");
+
+	/**
+	 * See [StarkSessionService setCurrentLanguage]{@link StarkSessionService#setCurrentLanguage} method
+	 */
+	public setCurrentLanguage: Spy<StarkSessionService["setCurrentLanguage"]> = createSpy("setCurrentLanguage");
+
+	/**
+	 * See [StarkSessionService login]{@link StarkSessionService#login} method
+	 */
+	public login: Spy<StarkSessionService["login"]> = createSpy("login");
+
+	/**
+	 * See [StarkSessionService logout]{@link StarkSessionService#logout} method
+	 */
+	public logout: Spy<StarkSessionService["logout"]> = createSpy("logout");
+
+	/**
+	 * See [StarkSessionService pauseUserActivityTracking]{@link StarkSessionService#pauseUserActivityTracking} method
+	 */
+	public pauseUserActivityTracking: Spy<StarkSessionService["pauseUserActivityTracking"]> = createSpy("pauseUserActivityTracking");
+
+	/**
+	 * See [StarkSessionService resumeUserActivityTracking]{@link StarkSessionService#resumeUserActivityTracking} method
+	 */
+	public resumeUserActivityTracking: Spy<StarkSessionService["resumeUserActivityTracking"]> = createSpy("resumeUserActivityTracking");
+
+	/**
+	 * See [StarkSessionService setDevAuthenticationHeaders]{@link StarkSessionService#setDevAuthenticationHeaders} method
+	 */
+	public setDevAuthenticationHeaders: Spy<StarkSessionService["setDevAuthenticationHeaders"]> = createSpy("setDevAuthenticationHeaders");
+
+	/**
+	 * Creates a new mock instance.
+	 * @param devAuthenticationHeaders - Development authentication headers to set to this instance
+	 */
+	public constructor(devAuthenticationHeaders?: Map<string, string | string[]>) {
 		if (!devAuthenticationHeaders) {
 			this.devAuthenticationHeaders = new Map<string, string>();
 		} else {

--- a/packages/stark-core/testing/src/session.mock.ts
+++ b/packages/stark-core/testing/src/session.mock.ts
@@ -54,7 +54,7 @@ export class MockStarkSessionService implements SpyObj<StarkSessionService> {
 
 	/**
 	 * Creates a new mock instance.
-	 * @param devAuthenticationHeaders - Development authentication headers to set to this instance
+	 * @param devAuthenticationHeaders Development authentication headers to set to this instance
 	 */
 	public constructor(devAuthenticationHeaders?: Map<string, string | string[]>) {
 		if (!devAuthenticationHeaders) {

--- a/packages/stark-core/testing/src/user.mock.ts
+++ b/packages/stark-core/testing/src/user.mock.ts
@@ -1,10 +1,18 @@
 import { StarkUserService } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 
 /**
- * @ignore
+ * Mock class of the {@link StarkUserService} interface.
  */
 export class MockStarkUserService implements SpyObj<StarkUserService> {
-	public fetchUserProfile: SpyObj<StarkUserService>["fetchUserProfile"] = jasmine.createSpy("fetchUserProfile");
-	public getAllUsers: SpyObj<StarkUserService>["getAllUsers"] = jasmine.createSpy("getAllUsers");
+	/**
+	 * See [StarkUserService fetchUserProfile]{@link StarkUserService#fetchUserProfile} method
+	 */
+	public fetchUserProfile: Spy<StarkUserService["fetchUserProfile"]> = jasmine.createSpy("fetchUserProfile");
+
+	/**
+	 * See [StarkUserService getAllUsers]{@link StarkUserService#getAllUsers} method
+	 */
+	public getAllUsers: Spy<StarkUserService["getAllUsers"]> = jasmine.createSpy("getAllUsers");
 }

--- a/packages/stark-core/testing/src/xsrf.mock.ts
+++ b/packages/stark-core/testing/src/xsrf.mock.ts
@@ -1,19 +1,34 @@
 import { StarkXSRFService } from "@nationalbankbelgium/stark-core";
+import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpy = jasmine.createSpy;
 
 /**
- * Mock class of the StarkXSRFService interface.
- * @link StarkXSRFService
+ * Mock class of the {@link StarkXSRFService} interface.
  */
 export class MockStarkXsrfService implements SpyObj<StarkXSRFService> {
-	public configureHttpRequest: SpyObj<StarkXSRFService>["configureHttpRequest"] = createSpy("configureHttpRequest");
+	/**
+	 * See [StarkXSRFService configureHttpRequest]{@link StarkXSRFService#configureHttpRequest} method
+	 */
+	public configureHttpRequest: Spy<StarkXSRFService["configureHttpRequest"]> = createSpy("configureHttpRequest");
 
-	public configureXHR: SpyObj<StarkXSRFService>["configureXHR"] = createSpy("configureXHR");
+	/**
+	 * See [StarkXSRFService configureXHR]{@link StarkXSRFService#configureXHR} method
+	 */
+	public configureXHR: Spy<StarkXSRFService["configureXHR"]> = createSpy("configureXHR");
 
-	public getXSRFToken: SpyObj<StarkXSRFService>["getXSRFToken"] = createSpy("getXSRFToken");
+	/**
+	 * See [StarkXSRFService getXSRFToken]{@link StarkXSRFService#getXSRFToken} method
+	 */
+	public getXSRFToken: Spy<StarkXSRFService["getXSRFToken"]> = createSpy("getXSRFToken");
 
-	public pingBackends: SpyObj<StarkXSRFService>["pingBackends"] = createSpy("pingBackends");
+	/**
+	 * See [StarkXSRFService pingBackends]{@link StarkXSRFService#pingBackends} method
+	 */
+	public pingBackends: Spy<StarkXSRFService["pingBackends"]> = createSpy("pingBackends");
 
-	public storeXSRFToken: SpyObj<StarkXSRFService>["storeXSRFToken"] = createSpy("storeXSRFToken");
+	/**
+	 * See [StarkXSRFService storeXSRFToken]{@link StarkXSRFService#storeXSRFToken} method
+	 */
+	public storeXSRFToken: Spy<StarkXSRFService["storeXSRFToken"]> = createSpy("storeXSRFToken");
 }


### PR DESCRIPTION
Small fix for your PR 😊
I removed all the dashes present after the `@param` tag

I did a replace all with IntelliJ

```text
Search: \@param\s(\w+)\s\-
Replace: @param $1
```

Like this, we have this result:
![image](https://user-images.githubusercontent.com/10333565/77922183-3cda0680-7290-11ea-96db-d9c15b63796c.png)

instead of:
![image](https://user-images.githubusercontent.com/10333565/77922365-77dc3a00-7290-11ea-9aae-a21a65e4a98c.png)

I think this should be done too in stark-ui and stark-rbac. 
What do you think ? 😊 